### PR TITLE
Upload menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 
 # Ignore uploaded files in development
  /public/uploads/
+
+ /.env

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem 'roo'
 gem 'cocoon'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'fog-aws'
+gem 'dotenv-rails'
+gem 'carrierwave-i18n'
 
 
 # ログイン機能

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    carrierwave-i18n (0.2.0)
     childprocess (3.0.0)
     choice (0.2.0)
     cocoon (1.2.15)
@@ -89,7 +90,12 @@ GEM
     devise-i18n (1.10.0)
       devise (>= 4.8.0)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
+    excon (0.88.0)
     execjs (2.7.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -99,6 +105,23 @@ GEM
     faker (2.17.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.0)
+    fog-aws (3.12.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.4)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)
@@ -106,6 +129,7 @@ GEM
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -131,10 +155,14 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.1115)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
+    multi_json (1.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
@@ -281,12 +309,15 @@ DEPENDENCIES
   byebug
   capybara
   carrierwave
+  carrierwave-i18n
   cocoon
   coffee-rails (~> 4.2)
   devise
   devise-i18n
+  dotenv-rails
   factory_bot_rails
   faker
+  fog-aws
   jbuilder (~> 2.5)
   jquery-rails
   letter_opener_web

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -21,15 +21,12 @@ class MenusController < ApplicationController
 
   # 献立表保存
   def create
-    if params[:menu][:menu_pdf].blank?
-      flash[:danger] = "ファイルを指定してください。"
-    elsif params[:menu][:menu_name].blank?
-      flash[:danger] = "ファイル名を入力してください。"
-    else
-      @menu = @school.menus.new(menu_params)
-      @menu.save
+    @menu = @school.menus.new(menu_params)
+    if @menu.save
       flash[:success] = '献立表を追加しました。'
       redirect_to teachers_menu_path(@menu) and return
+    else
+      flash[:danger] = "作成に失敗しました。<br>・#{@menu.errors.full_messages.join('<br>・')}"
     end
     redirect_to teachers_menus_path and return
   end
@@ -40,16 +37,13 @@ class MenusController < ApplicationController
 
   # 献立表更新
   def update
-    if params[:menu][:menu_pdf].blank?
-      flash[:danger] = "ファイルを指定してください。"
-    elsif params[:menu][:menu_name].blank?
-      flash[:danger] = "ファイル名を入力してください。"
-    else
-      @menu.update_attributes(menu_params)
+    if @menu.update_attributes(menu_params)
       flash[:success] = "献立表を更新しました。"
-      redirect_to teachers_menus_path and return
-    end
-    redirect_to teachers_menus_path and return
+      redirect_to teachers_menu_path(@menu) and return
+    else
+      flash[:danger] = "更新に失敗しました。<br>・#{@menu.errors.full_messages.join('<br>・')}"
+  end
+  redirect_to teachers_menus_path and return
   end
 
   # 献立表削除

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -23,7 +23,7 @@ class TeachersController < ApplicationController
       flash[:success] = "担任を作成しました。"
       redirect_to classrooms_path and return
     else
-      flash[:danger] = "作成に失敗しました。<br>" + "・" + @teacher.errors.full_messages.join("<br>")
+      flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"
     end
     redirect_to classrooms_path and return
   end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,4 +1,7 @@
 class Menu < ApplicationRecord
   belongs_to :school
   mount_uploader :menu_pdf, PdfUploader
+
+  validates :menu_name, presence: true
+  validates :menu_pdf, presence: true
 end

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -1,16 +1,25 @@
 class PdfUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.development? # 開発環境の場合
+    storage :file
+  elsif Rails.env.test? # テスト環境の場合
+    storage :file
+  else # 本番環境の場合
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # ファイルサイズに制限をつける
+  def size_range
+    1..5.megabytes
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
@@ -35,9 +44,9 @@ class PdfUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w(pdf)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/menus/_edit.html.erb
+++ b/app/views/menus/_edit.html.erb
@@ -15,6 +15,7 @@
 
         <div class="form-group">
           <%= f.label :menu_pdf %>
+          <%= @menu.menu_pdf.file.original_filename if @menu.menu_pdf? %>
           <%= f.file_field :menu_pdf %>
         </div>
         <%= f.submit "更新する", class: "btn btn-primary btn-block" %>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,25 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+# ファイル名を日本語で表示
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/
+
+CarrierWave.configure do |config|
+  if Rails.env.production? # 本番環境の場合はS3へアップロード
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'school_allergy' # バケット名
+    config.fog_public = true
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # アクセスキー
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # シークレットアクセスキー
+      region: ENV['AWS_DEFAULT_REGION'], # リージョン
+      path_style: true
+    }
+  else # 本番環境以外の場合はアプリケーション内にアップロード
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,16 @@ ja:
   activerecord:
     errors:
       messages:
+        carrierwave_processing_error: failed to be processed
+        carrierwave_integrity_error: is not of an allowed file type
+        carrierwave_download_error: could not be downloaded
+        extension_allowlist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+        extension_denylist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+        content_type_allowlist_error: "You are not allowed to upload %{content_type} files, allowed types: %{allowed_types}"
+        content_type_denylist_error: "You are not allowed to upload %{content_type} files"
+        processing_error: "Failed to manipulate, maybe it is not an image?"
+        min_size_error: "File size should be greater than %{min_size}"
+        max_size_error: "File size should be less than %{max_size}"
         record_invalid: 'バリデーションに失敗しました: %{errors}'
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"


### PR DESCRIPTION
【機能名】：献立表追加機能
【ブランチ名】：upload-menu
【進捗率】：100%

【今回実装内容】
・本番環境への設定（環境変数は.envファイルにて管理）
・指定ファイル形式（PDF）以外の投稿制限設定
・バリデーション追加
・carrierwaveのエラー日本語化
・編集モーダルに元ファイル名表示追加

【備考】
・AWSでの設定は未着手の為、環境変数の中身は未設定