### PR TITLE
担任ページ、報告機能の修正

### DIFF
--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -8,8 +8,7 @@ class AlergyChecksController < ApplicationController
 
   def today_index
     @alergy_checks = @classroom.alergy_checks.today.order(:student_id)
-    @teachers = Teacher.where(school_id: current_teacher.school_id).where.not(admin: true) # 管理職以外の代理報告時
-    @all_teachers = Teacher.where(school_id: current_teacher.school_id) # 管理職の代理報告時
+    @teachers = Teacher.where(school_id: current_teacher.school_id) # 代理報告時に選択
   end
 
   def update
@@ -17,19 +16,28 @@ class AlergyChecksController < ApplicationController
     # 同じschool_idを持つ児童しか選択できない
     if current_teacher.school.id != @alergy_check.student.school_id
       flash[:danger] = "許可されていない操作が行われました。"
-      return redirect_to teachers_alergy_checks_url
+      # 代理報告か否かでリダイレクト先を分岐
+      if proxy_report_check
+        return redirect_to teachers_charger_alergy_checks_url
+      else
+        return redirect_to teachers_alergy_checks_url
+      end
     end
 
     #バリデーションチェック前の値セット
-    @alergy_check.assign_attributes(today_check_params)
+    if proxy_report_check
+      @alergy_check.assign_attributes(proxy_today_check_params)
+    else
+      @alergy_check.assign_attributes(today_check_params)
+    end
 
     if @alergy_check.valid?(:today_check) && @alergy_check.save
       flash[:success] = "#{@alergy_check.student.student_name}のチェックを報告しました。"
     else
       flash[:danger] = "#{@alergy_check.student.student_name}のチェック報告に失敗しました。<br>" + "・" + @alergy_check.errors.full_messages.join("<br>・")
     end
-    previous_path = Rails.application.routes.recognize_path(request.referrer)
-    if previous_path[:controller] == "charger_alergy_checks" && previous_path[:action] == "show"
+    # 代理報告か否かでリダイレクト先を分岐
+    if proxy_report_check
       redirect_to teachers_charger_alergy_checks_url
     else
       redirect_to teachers_alergy_checks_url
@@ -44,16 +52,26 @@ class AlergyChecksController < ApplicationController
   end
 
   private
+    # 代理報告か確認
+    def proxy_report_check
+      !!params[:proxy_flag] || params[:alergy_check][:proxy_flag]
+    end
+
     def set_classroom
-      previous_path = Rails.application.routes.recognize_path(request.referrer)
-      if previous_path[:controller] == "charger_alergy_checks" && previous_path[:action] == "show"
+      if params[:select_classroom]
         @classroom = Classroom.find(params[:select_classroom])
       else
         @classroom = current_teacher.classroom
       end
     end
 
+    # 自クラス報告用
     def today_check_params
+      params.require(:alergy_check).permit(:first_check, :second_check, :student_check).merge(applicant: current_teacher.teacher_name, status: "報告中")
+    end
+
+    # 代理報告用
+    def proxy_today_check_params
       params.require(:alergy_check).permit(:first_check, :second_check, :student_check, :applicant).merge(status: "報告中")
     end
 end

--- a/app/views/alergy_checks/_today_index.html.erb
+++ b/app/views/alergy_checks/_today_index.html.erb
@@ -41,16 +41,22 @@
                     <td><%= f.check_box :first_check, { required: true }, true, false %></td>
                     <td><%= f.check_box :second_check, { required: true }, true, false %></td>
                     <td><%= f.check_box :student_check, { required: true }, true, false %></td>
-                    <td><%= f.collection_select :applicant, @teachers, :teacher_name, :teacher_name, 
-                                                { include_blank: "申請者名を選択" }, { class: "form-control", required: true } %></td>
+                    <!-- 代理報告の場合 -->
+                    <% if params[:proxy_flag] %>
+                      <td><%= f.collection_select :applicant, @teachers, :teacher_name, :teacher_name, 
+                                                  { include_blank: "申請者名を選択" }, { class: "form-control", required: true } %></td>
+                      <%= f.hidden_field :proxy_flag, :value => params[:proxy_flag] %>
+                    <!-- 自クラス報告の場合 -->
+                    <% else %>
+                      <td><%= current_teacher.teacher_name %></td>
+                    <% end %>
                     <td><%= Teacher.human_attribute_name(:admin) %></td>
                     <td><%= f.submit "#{check_state(alergy_check.status)}", class: "btn btn-primary btn-sm" %></td>
                   <% else %>
                     <td><%= f.check_box :first_check, { disabled: true }, true, false %></td>
                     <td><%= f.check_box :second_check, { disabled: true }, true, false %></td>
                     <td><%= f.check_box :student_check, { disabled: true }, true, false %></td>
-                    <td><%= f.collection_select :applicant, @teachers, :teacher_name, :teacher_name, 
-                                                { include_blank: "申請者名を選択" }, { class: "form-control", disabled: true } %></td>
+                    <td><%= alergy_check.applicant %></td>
                     <td><%= Teacher.human_attribute_name(:admin) %></td>
                     <td><%= f.submit "#{check_state(alergy_check.status)}", { class: "btn btn-primary btn-sm", disabled: true } %></td>
                   <% end %>

--- a/app/views/alergy_checks/show.html.erb
+++ b/app/views/alergy_checks/show.html.erb
@@ -3,10 +3,14 @@
     <br><%= I18n.l(Date.current, format: :long) %><br><br>
     <span>クラス：<%= @classroom.class_name %></span>
     <%= link_to "月間チェック", one_month_index_teachers_alergy_checks_path, class: "btn btn-warning btn-lg button__monthly-check" %><br><br>
-    <% if @alergy_check_sum == @submitted %>  
-      本日のチェックは完了しました。
+    <% if @alergy_check_sum == 0 %>
+      本日のチェックはありません。
     <% else %>
-      本日のアレルギーチェック：<%= "#{@alergy_check_sum}件" %>
+      <% if @alergy_check_sum == @submitted %>  
+        本日のチェックは完了しました。
+      <% else %>
+        本日のチェック：<%= "#{@alergy_check_sum}件" %>
+      <% end %>
     <% end %>
   </div>
   <div class="area">

--- a/app/views/charger_alergy_checks/show.html.erb
+++ b/app/views/charger_alergy_checks/show.html.erb
@@ -10,6 +10,7 @@
   <% else %>
     <div class="col-md-2 col-md-offset-5 form__select-classroom">
       <%= form_with(url: today_index_teachers_alergy_checks_path, method: :get) do |f| %>
+        <%= f.hidden_field :proxy_flag, :value => true %>
         <%= f.collection_select :select_classroom, @classrooms, :id, :class_name, 
                                 { include_blank: "クラス名を選択" }, { class: "form-control", required: true } %>
         <%= f.submit "代理報告する", class: "btn btn-primary button__proxy--position" %>


### PR DESCRIPTION
【やったこと】
・代理報告と自クラス報告で、報告者名選択部分のビューを切り替え 
　→自クラス報告では、報告者をcurrent_teacherで固定、代理報告ではセレクトボックスに全職員を表示
・CSS使い回しのため＋チェックがない日も「チェック完了しました」のメッセージが表示されてしまっていたため、担任ページのビューを修正
【備考】
・モデルのテストコードも追加予定だったのですが、管理職用の月間チェック一覧ページ作成を優先のため、一旦切り上げてPRを出させていただきます。
・月間チェック一覧ページ(担任)の確認者名の表示修正が必要なので、これから着手する月間チェック一覧ページ(管理職)と併せて修正します。
