### PR TITLE
全学級(管理職)月間チェック一覧ページの作成

### DIFF
--- a/app/controllers/admin_alergy_checks_controller.rb
+++ b/app/controllers/admin_alergy_checks_controller.rb
@@ -1,0 +1,6 @@
+class AdminAlergyChecksController < ApplicationController
+
+  def one_month_index
+  end
+  
+end

--- a/app/controllers/admin_alergy_checks_controller.rb
+++ b/app/controllers/admin_alergy_checks_controller.rb
@@ -1,6 +1,10 @@
 class AdminAlergyChecksController < ApplicationController
+before_action :set_first_last_day
 
   def one_month_index
+    @alergy_checks = AlergyCheck.joins({student: {classroom: :school}})
+                                .where(:schools =>{:id => current_teacher.school_id}, worked_on: @first_day..@last_day)
+                                .order(:worked_on)
   end
-  
+
 end

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -40,7 +40,6 @@ class AlergyChecksController < ApplicationController
     @days_of_the_week = %w{日 月 火 水 木 金 土}
     @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date
     @last_day = @first_day.end_of_month
-    debugger
     @alergy_checks = @classroom.alergy_checks.where(worked_on: @first_day..@last_day).order(:worked_on)
   end
 

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -1,5 +1,6 @@
 class AlergyChecksController < ApplicationController
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
+  before_action :set_first_last_day, only: :one_month_index
 
   def show
     @submitted = @classroom.alergy_checks.today.where.not(status: "").count #報告済み件数
@@ -37,9 +38,6 @@ class AlergyChecksController < ApplicationController
   end
 
   def one_month_index
-    @days_of_the_week = %w{日 月 火 水 木 金 土}
-    @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date
-    @last_day = @first_day.end_of_month
     @alergy_checks = @classroom.alergy_checks.where(worked_on: @first_day..@last_day).order(:worked_on)
   end
 

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -40,6 +40,7 @@ class AlergyChecksController < ApplicationController
     @days_of_the_week = %w{日 月 火 水 木 金 土}
     @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date
     @last_day = @first_day.end_of_month
+    debugger
     @alergy_checks = @classroom.alergy_checks.where(worked_on: @first_day..@last_day).order(:worked_on)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,9 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
-
-
-  # ---------下記既存アプリの記述-------------------
   $days_of_the_week = %w{日 月 火 水 木 金 土}
 
+  # ---------下記既存アプリの記述-------------------
   # ページ出力前に1ヶ月分のデータの存在を確認・セットします。
  def set_one_month
   @first_day = params[:date].nil? ?
@@ -45,5 +43,11 @@ class ApplicationController < ActionController::Base
   # 管理者かどうかの判定
   def admin_teacher
     redirect_to top_pathaaaa unless current_teacher.admin?
+  end
+
+  # 今日の日付からその月の初日と最終日を取得
+  def set_first_last_day
+    @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date
+    @last_day = @first_day.end_of_month
   end
 end

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -3,6 +3,7 @@ class TeachersController < ApplicationController
 
   before_action :authenticate_teacher!
   before_action :admin_teacher, only: [:new, :create, :edit_info, :update_info, :destroy]
+  before_action :set_first_last_day, only: :creator
 
 
   def index
@@ -52,8 +53,6 @@ class TeachersController < ApplicationController
   # 対応法担当者ページ(show)
   def creator
     @days_of_the_week = %w{日 月 火 水 木 金 土}
-    @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date
-    @last_day = @first_day.end_of_month
     @one_month = [*@first_day..@last_day]
     @students = Student.all
   end

--- a/app/helpers/alergy_checks_helper.rb
+++ b/app/helpers/alergy_checks_helper.rb
@@ -10,14 +10,14 @@ module AlergyChecksHelper
   end
 
   # 月間チェック一覧ページステータス表示
-  def monthly_check_state(status)
+  def monthly_check_state(status:, name:)
     case status
     when "" then
       return "未報告"
     when "報告中" then
-      return "管理職へ#{status}"
+      return "#{name}へ#{status}"
     when "確認済"
-      return "管理職#{status}"
+      return "#{name} #{status}"
     end
   end
 

--- a/app/views/admin_alergy_checks/one_month_index.html.erb
+++ b/app/views/admin_alergy_checks/one_month_index.html.erb
@@ -1,0 +1,52 @@
+<h1>管理職月間チェック一覧</h1>
+<div class="button__monthly">
+  <%= link_to "前月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.prev_month), class: "btn btn-info" %>
+  <%= link_to "次月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.next_month), class: "btn btn-info" %>
+</div>
+
+<div>
+  <% if @alergy_checks.any? %>
+    <table class="table table-bordered table-condensed table-hover table__alergy-contents--center">
+      <thead>
+        <tr>
+            <th><%= AlergyCheck.human_attribute_name(:worked_on) %></th>
+            <th><%= Classroom.human_attribute_name(:class_name) %></th>
+            <th><%= Student.human_attribute_name(:student_name) %></th>
+            <th><%= AlergyCheck.human_attribute_name(:menu) %></th>
+            <th><%= AlergyCheck.human_attribute_name(:support) %></th>
+            <th><%= AlergyCheck.human_attribute_name(:note) %></th>
+            <th><%= AlergyCheck.human_attribute_name(:applicant_id) %></th>
+            <th><%= AlergyCheck.human_attribute_name(:status) %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%# 日付被り非表示チェック用変数 %>
+        <% previous_worked_on = nil %>
+        <% @alergy_checks.each do |alergy_check| %>
+          <tr>
+            <%# 日付被り非表示チェック %>
+            <% if alergy_check.worked_on == previous_worked_on %>
+              <td></td>
+            <% else %>
+              <td><%= l(alergy_check.worked_on, format: :short) + "(#{$days_of_the_week[alergy_check.worked_on.wday]})" %></td>
+            <% end %>
+            <% previous_worked_on = alergy_check.worked_on %>
+
+            <%# 管理職用の月間チェックではクラス名を表示 %>
+            <td><%= alergy_check.student.classroom.class_name %></td>
+            <td><%= alergy_check.student.student_name %></td>
+            <td><%= alergy_check.menu %></td>
+            <td><%= alergy_check.support %></td>
+            <td><%= note(alergy_check.note) %></td>
+            <td><%= alergy_check.applicant %></td>
+            <td>
+              <%= monthly_check_state(alergy_check.status) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <h1 style="font-size:2em"><%= "#{@first_day.month}月のチェック情報はありません。" %></h1>
+  <% end %>
+</div>

--- a/app/views/admin_alergy_checks/one_month_index.html.erb
+++ b/app/views/admin_alergy_checks/one_month_index.html.erb
@@ -1,4 +1,4 @@
-<h1>管理職月間チェック一覧</h1>
+<h1>全学級月間チェック一覧</h1>
 <div class="button__monthly">
   <%= link_to "前月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.prev_month), class: "btn btn-info" %>
   <%= link_to "次月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.next_month), class: "btn btn-info" %>
@@ -28,7 +28,8 @@
             <% if alergy_check.worked_on == previous_worked_on %>
               <td></td>
             <% else %>
-              <td><%= l(alergy_check.worked_on, format: :short) + "(#{$days_of_the_week[alergy_check.worked_on.wday]})" %></td>
+              <td><%= l(alergy_check.worked_on, format: :short) + 
+                      "(#{$days_of_the_week[alergy_check.worked_on.wday]})" %></td>
             <% end %>
             <% previous_worked_on = alergy_check.worked_on %>
 
@@ -40,7 +41,7 @@
             <td><%= note(alergy_check.note) %></td>
             <td><%= alergy_check.applicant %></td>
             <td>
-              <%= monthly_check_state(alergy_check.status) %>
+              <%= monthly_check_state(status: alergy_check.status, name: alergy_check.admin_name) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/alergy_checks/one_month_index.html.erb
+++ b/app/views/alergy_checks/one_month_index.html.erb
@@ -31,7 +31,8 @@
             <% if alergy_check.worked_on == previous_worked_on %>
               <td></td>
             <% else %>
-              <td><%= l(alergy_check.worked_on, format: :short) + "(#{$days_of_the_week[alergy_check.worked_on.wday]})" %></td>
+              <td><%= l(alergy_check.worked_on, format: :short) + 
+                      "(#{$days_of_the_week[alergy_check.worked_on.wday]})" %></td>
             <% end %>
             <% previous_worked_on = alergy_check.worked_on %>
 
@@ -41,7 +42,7 @@
             <td><%= note(alergy_check.note) %></td>
             <td><%= alergy_check.applicant %></td>
             <td>
-              <%= monthly_check_state(alergy_check.status) %>
+              <%= monthly_check_state(status: alergy_check.status, name: alergy_check.admin_name) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/layouts/_teacher_header.html.erb
+++ b/app/views/layouts/_teacher_header.html.erb
@@ -14,6 +14,7 @@
     <% unless current_teacher.charger? %>
       <li><%= link_to '月間チェック一覧', one_month_index_teachers_alergy_checks_path %></li>
     <% end %>
+    <li><%= link_to '全学級月間チェック一覧', admin_alergy_checks_one_month_index_teachers_path %></li>
     <li class="divider"></li>
     <li>
       <li><%= link_to 'ログアウト', destroy_teacher_session_path, method: :delete %></li>

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -31,6 +31,12 @@ ja:
           school_url: 学校コード
           created_at: 作成日
           updated_at: 更新日
+        classroom:
+          class_name: 学級名
+          class_grade:
+          using_class:
+          created_at: 作成日
+          updated_at: 更新日
         teacher:
           email: メールアドレス
           teacher_name: 名前

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,9 +71,7 @@ Rails.application.routes.draw do
 
     #管理職月間チェック一覧ページ
     collection do
-      namespace :admin_alergy_checks do
-        get 'one_month_index'
-      end
+      get '/admin_alergy_checks/one_month_index'
     end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,13 @@ Rails.application.routes.draw do
     #代理報告ページ
     resource :charger_alergy_checks, only: %i(show)
 
+    #管理職月間チェック一覧ページ
+    collection do
+      namespace :admin_alergy_checks do
+        get 'one_month_index'
+      end
+    end
+
 
   end
   resource :students do

--- a/db/migrate/20211201110653_add_admin_name_to_alergy_checks.rb
+++ b/db/migrate/20211201110653_add_admin_name_to_alergy_checks.rb
@@ -1,0 +1,5 @@
+class AddAdminNameToAlergyChecks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :alergy_checks, :admin_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211123072851) do
+ActiveRecord::Schema.define(version: 20211201110653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20211123072851) do
     t.string "menu", null: false
     t.string "support", null: false
     t.string "applicant"
+    t.string "admin_name"
     t.index ["student_id"], name: "index_alergy_checks_on_student_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,10 @@ end
 
 puts "SystemAdmin Created"
 
-School.create!(school_name: "サンプル",
-               school_url: "sample1")
+2.times do |n|
+  School.create!(school_name: "サンプル#{n+1}",
+                school_url: "sample#{n+1}")
+end
 
 puts "School Created"
 
@@ -39,13 +41,20 @@ User.create!(name: "担当",
 
 puts "User Created"
 
-# 1-1のクラス作成
+# クラス作成
 classroom_id = 1
-Classroom.create!(class_name: "1-1",
-                school_id: 1)
+2.times do |n|
+  Classroom.create!(class_name: "#{n+1}-1",
+                  school_id: 1)
+end
+2.times do |n|
+  Classroom.create!(class_name: "#{n+1}-a",
+                  school_id: 2)
+  end
+puts "Classroom Created"           
 
 Teacher.create!(teacher_name: "管理職",
-              email: "admin@email.com",
+              email: "adminA@email.com",
               password: "password",
               password_confirmation: "password",
               admin: true,
@@ -84,11 +93,17 @@ end
 
 puts "1-1Student Created"
 
-classroom_id = 2
-Classroom.create!(class_name: "2-1",
-                school_id: 1)
+classroom_id = 3
+Teacher.create!(teacher_name: "管理職",
+  email: "adminB@email.com",
+  password: "password",
+  password_confirmation: "password",
+  admin: true,
+  school_id: 2,
+  tcode: "kanri2",
+  classroom_id: classroom_id) 
 
-3.times do |n|
+2.times do |n|
   name  = Faker::Name.name
   email = "teacher#{n+1}@email.com"
   tcode = Faker::Alphanumeric.alphanumeric(number: 4, min_alpha: 1, min_numeric: 1)
@@ -97,7 +112,7 @@ Classroom.create!(class_name: "2-1",
               email: email,
               password: password,
               password_confirmation: password,
-              school_id: 1,
+              school_id: 2,
               tcode: tcode,
               classroom_id: classroom_id)
 end
@@ -108,7 +123,7 @@ puts "2-1Teacher Created"
   number = 2100 + n + 1
   Student.create!(student_name: name,
                   student_number: number,
-                  school_id: 1,
+                  school_id: 2,
                   classroom_id: classroom_id)
 end
 


### PR DESCRIPTION
【やったこと】
・alergy_checksテーブルに、報告を確認した管理職の名前を格納するカラム(admin_name)を追加。
・全学級のアレルギー情報が参照できるよう、ページを作成。
・学校ごとの表示データ絞り込み確認のため、2校目の学校、クラス、児童、先生のデータを作成する処理をseeds.rbに追加。
・ページ作成と併せて、同様の処理があったteachers_controller(createrアクション)とalergy_checks_controller(one_month_indexアクション)をリファクタリング。

【備考】
・管理職だけでなく、全ての職員が参照できること、という要望があったため、ページのタイトルを
「管理職月間チェック一覧ページ」から「全学級月間チェック一覧ページ」に変更しました。問題があれば、今後の担任用の月間チェック一覧ページのビュー修正と併せて、こちらも修正します。