### PR TITLE
Fix creator page 3

### DIFF
--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -1,6 +1,7 @@
 class AlergyChecksController < ApplicationController
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
   before_action :set_first_last_day, only: :one_month_index
+  before_action :have_class_room?, only: :one_month_index
 
   def show
     @submitted = @classroom.alergy_checks.today.where.not(status: "").count #報告済み件数
@@ -61,6 +62,11 @@ class AlergyChecksController < ApplicationController
       else
         @classroom = current_teacher.classroom
       end
+    end
+
+    # クラスを持つ職員かどうかの判定
+    def have_class_room?
+      redirect_to show_teachers_path unless Classroom.exists?(current_teacher.classroom_id)
     end
 
     # 自クラス報告用

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -66,7 +66,10 @@ class AlergyChecksController < ApplicationController
 
     # クラスを持つ職員かどうかの判定
     def have_class_room?
-      redirect_to show_teachers_path unless Classroom.exists?(current_teacher.classroom_id)
+      unless Classroom.exists?(current_teacher.classroom_id)
+        flash[:danger] = "許可されていない操作です。"
+        redirect_to show_teachers_path
+      end
     end
 
     # 自クラス報告用

--- a/app/controllers/charger_alergy_checks_controller.rb
+++ b/app/controllers/charger_alergy_checks_controller.rb
@@ -1,6 +1,7 @@
 class ChargerAlergyChecksController < ApplicationController
 
   def show
+    # ログインしている職員の学校内で、本日チェックが必要なアレルギー情報を抽出
     @classrooms = Classroom.includes(students: :alergy_checks).where(school_id: current_teacher.school.id, alergy_checks: {worked_on: Date.current})
   end
 

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -10,7 +10,7 @@ class CreatorAlergyChecksController < ApplicationController
     @student = Student.new
     @alergy_check = @student.alergy_checks.build
     @day = params[:day].to_date
-    @classrooms = current_teacher.school.classrooms
+    @classrooms = current_teacher.school.classrooms.where(using_class: true)
   end
 
   def create
@@ -21,7 +21,8 @@ class CreatorAlergyChecksController < ApplicationController
           student.alergy_checks.create!(
             worked_on:  v[:worked_on],
             menu:       v[:menu],
-            support:    v[:support]
+            support:    v[:support],
+            note:       v[:note]
           )
         end
       end
@@ -38,7 +39,7 @@ class CreatorAlergyChecksController < ApplicationController
     @alergy_check = AlergyCheck.find(params[:id])
     @student = @alergy_check.student
     @classroom = current_teacher.school.classrooms.find(@student.classroom_id)
-    @classrooms = current_teacher.school.classrooms
+    @classrooms = current_teacher.school.classrooms.where(using_class: true)
   end
 
   def update

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -3,7 +3,7 @@ class CreatorAlergyChecksController < ApplicationController
 
   def index
     @one_month = [*@first_day..@last_day]
-    @students = Student.all
+    @students = Student.where(school_id: current_teacher.school_id)
   end
 
   def new

--- a/app/views/admin_alergy_checks/one_month_index.html.erb
+++ b/app/views/admin_alergy_checks/one_month_index.html.erb
@@ -1,7 +1,7 @@
 <h1>全学級月間チェック一覧</h1>
 <div class="button__monthly">
-  <%= link_to "前月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.prev_month), class: "btn btn-info" %>
-  <%= link_to "次月", admin_alergy_checks_one_month_index_teachers_path(date: @first_day.next_month), class: "btn btn-info" %>
+  <%= link_to "前月", one_month_index_teachers_admin_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>
+  <%= link_to "次月", one_month_index_teachers_admin_alergy_checks_path(date: @first_day.next_month), class: "btn btn-info" %>
 </div>
 
 <%= render partial: 'alergy_checks/check_index', locals: { alergy_checks: @alergy_checks } %>

--- a/app/views/creator_alergy_checks/_edit.html.erb
+++ b/app/views/creator_alergy_checks/_edit.html.erb
@@ -62,7 +62,7 @@ $(document).on("change", "#select--classroom", function () {
   // ajaxでリクエストを送信
   $.ajax({
     type: "GET",
-    url: "/students/alergy_checks/creator/students",
+    url: "/teachers/creator_alergy_checks/students",
     data: {classroom_id: classroom_id},
     dataType: 'json'
   })

--- a/app/views/layouts/_teacher_header.html.erb
+++ b/app/views/layouts/_teacher_header.html.erb
@@ -9,7 +9,7 @@
     <% unless current_teacher.charger? %>
       <li><%= link_to '月間チェック一覧', one_month_index_teachers_alergy_checks_path %></li>
     <% end %>
-    <li><%= link_to '全学級月間チェック一覧', admin_alergy_checks_one_month_index_teachers_path %></li>
+    <li><%= link_to '全学級月間チェック一覧', one_month_index_teachers_admin_alergy_checks_path %></li>
     <% if current_teacher.admin? %>
       <li><%= link_to '職員登録', new_teacher_registration_path %></li>
       <li><%= link_to '職員一覧', classrooms_path %></li>

--- a/app/views/layouts/_teacher_header.html.erb
+++ b/app/views/layouts/_teacher_header.html.erb
@@ -6,7 +6,6 @@
     <li><%= link_to '本日の作業', show_teachers_path %></li>
     <li><%= link_to '献立表', teachers_menus_path %></li>
     <li><%= link_to '児童一覧', teachers_school_students_path %></li>
-    <%# リファクタリングしたい %>
     <% if !current_teacher.charger? && Classroom.exists?(current_teacher.classroom_id) %>
       <li><%= link_to '月間チェック一覧', one_month_index_teachers_alergy_checks_path %></li>
     <% end %>

--- a/app/views/layouts/_teacher_header.html.erb
+++ b/app/views/layouts/_teacher_header.html.erb
@@ -6,7 +6,8 @@
     <li><%= link_to '本日の作業', show_teachers_path %></li>
     <li><%= link_to '献立表', teachers_menus_path %></li>
     <li><%= link_to '児童一覧', teachers_school_students_path %></li>
-    <% unless current_teacher.charger? %>
+    <%# リファクタリングしたい %>
+    <% if !current_teacher.charger? && Classroom.exists?(current_teacher.classroom_id) %>
       <li><%= link_to '月間チェック一覧', one_month_index_teachers_alergy_checks_path %></li>
     <% end %>
     <li><%= link_to '全学級月間チェック一覧', one_month_index_teachers_admin_alergy_checks_path %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,18 +94,18 @@ Rails.application.routes.draw do
   end
 
   resource :teachers do
-  resources :admin_alergy_checks, only: [:show] do
-    collection do  
-      get 'lunch_check'
-      patch 'update_lunch_check'
-    end   
-    member do
-       get 'lunch_check_info'
-       patch 'update_lunch_check_info'
-       get 'lunch_check_all'
-       patch 'update_lunch_check_all' 
-    end #collection do end
-   end #resouces do end
+    resources :admin_alergy_checks, only: [:show] do
+      collection do  
+        get 'lunch_check'
+        patch 'update_lunch_check'
+      end   
+      member do
+        get 'lunch_check_info'
+        patch 'update_lunch_check_info'
+        get 'lunch_check_all'
+        patch 'update_lunch_check_all' 
+      end #collection do end
+    end #resouces do end
   end #teachers do end
 
   # 下記山田さん既存のルート
@@ -128,14 +128,14 @@ Rails.application.routes.draw do
     end
 
     resources :attendances, only: [:edit, :update] do
-     member do
-       get 'lunch_check'
-       patch 'update_lunch_check'
-     end
-     collection do
+      member do
+        get 'lunch_check'
+        patch 'update_lunch_check'
+      end
+      collection do
         get 'lunch_check_info'
         patch 'update_lunch_check_info'
-     end #collection do end
+      end #collection do end
     end #resouces do end
   end #user resouces do end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,16 +44,22 @@ Rails.application.routes.draw do
         get '/students', to: 'creator_alergy_checks#search_student'
       end
     end
+
+    #管理職月間チェック一覧ページ
+    collection do
+      get '/admin_alergy_checks/one_month_index'
+    end
+
     resources :admin_alergy_checks, only: %i(show) do
       collection do  
         get 'lunch_check'
         patch 'update_lunch_check'
       end   
       member do
-         get 'lunch_check_info'
-         patch 'update_lunch_check_info'
+        get 'lunch_check_info'
+        patch 'update_lunch_check_info'
       end #collection do end
-     end #resouces do end
+    end #resouces do end
     resources :admin_alergy_checks, only: %i(show) do
     end
     resource :students do
@@ -80,20 +86,7 @@ Rails.application.routes.draw do
     #代理報告ページ
     resource :charger_alergy_checks, only: %i(show)
 
-    #管理職月間チェック一覧ページ
-    collection do
-      get '/admin_alergy_checks/one_month_index'
-    end
-
-
   end
-  # resource :students do
-  #   namespace :alergy_checks do
-  #     resource :creator, only: %i(new create) do
-  #       get '/students', to: 'creators#search_student'
-  #     end
-  #   end
-  # end
 
   resources :classrooms do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,14 +44,10 @@ Rails.application.routes.draw do
         get '/students', to: 'creator_alergy_checks#search_student'
       end
     end
-
-    #管理職月間チェック一覧ページ
-    collection do
-      get '/admin_alergy_checks/one_month_index'
-    end
-
+    # 管理職ページ
     resources :admin_alergy_checks, only: %i(show) do
-      collection do  
+      collection do
+        get 'one_month_index'
         get 'lunch_check'
         patch 'update_lunch_check'
       end   
@@ -60,8 +56,6 @@ Rails.application.routes.draw do
         patch 'update_lunch_check_info'
       end #collection do end
     end #resouces do end
-    resources :admin_alergy_checks, only: %i(show) do
-    end
     resource :students do
       namespace :alergy_checks do
         resource :creator, only: %i(new create)


### PR DESCRIPTION
【やったこと】
・対応法作成ページに関わる不具合の修正
トレロのカード → https://trello.com/c/9393dM5t
・ヘッダーメニュー内リンクの修正
トレロのカード → https://trello.com/c/Qe7x9l44

【動作確認】
・備考カラムの値も保存ができること、保存した値が対応法詳細一覧がページのビューで表示されることを確認
・一般、対応法作成、代理報告、管理職それぞれの職員のアカウントにログインし、ヘッダーのリンクから全学級月間チェック一覧ページへ遷移できることを確認
