### PR TITLE
献立表のファイル名被りバリデーション追加

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -42,8 +42,8 @@ class MenusController < ApplicationController
       redirect_to teachers_menu_path(@menu) and return
     else
       flash[:danger] = "更新に失敗しました。<br>・#{@menu.errors.full_messages.join('<br>・')}"
-  end
-  redirect_to teachers_menus_path and return
+    end
+    redirect_to teachers_menus_path and return
   end
 
   # 献立表削除

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -29,12 +29,12 @@ class TeachersController < ApplicationController
 
   def update_info
     @teacher = current_school.teachers.find(params[:teacher][:id])
-    if @teacher.update_attributes!(teachers_params)
+    if @teacher.update_attributes(teachers_params)
       flash[:success] = "職員情報を更新しました。"
-      redirect_to classrooms_path
     else
-      render :edit
+      flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"
     end
+    redirect_to classrooms_path
   end
 
   def destroy

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,6 +2,6 @@ class Menu < ApplicationRecord
   belongs_to :school
   mount_uploader :menu_pdf, PdfUploader
 
-  validates :menu_name, presence: true
+  validates :menu_name, presence: true, uniqueness: { scope: :school_id }
   validates :menu_pdf, presence: true
 end


### PR DESCRIPTION
【やった事】
○献立表にて、ファイル名被りのバリデーション追加
○担任編集にて、更新時エラーが上手く表示されない部分を解消

【動作確認】
○献立表追加にて、ファイル名が被っていた場合エラーが出る事を確認済