### PR TITLE
システム管理者または職員でログイン中は他のリソースでログインできないように調整

### DIFF
--- a/app/controllers/system_admins/sessions_controller.rb
+++ b/app/controllers/system_admins/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class SystemAdmins::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :check_current_teacher, only: [:new]
 
   # GET /resource/sign_in
   # def new
@@ -24,4 +25,13 @@ class SystemAdmins::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  private
+
+  def check_current_teacher
+    if current_teacher
+      flash[:danger] = '現在職員でログイン中です。システム管理者でログインする場合は一度ログアウトしてください。'
+      redirect_to show_teachers_url
+    end
+  end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -2,7 +2,8 @@
 
 class Teachers::SessionsController < Devise::SessionsController
   # before_action :system_admin_not_show, only: [:create]
-  before_action :set_school, only: [:new, :create]
+  before_action :check_current_system_admin, only: [:new]
+  before_action :set_school, only: %i[new create]
   before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -37,7 +38,7 @@ class Teachers::SessionsController < Devise::SessionsController
 
   # ログイン時のストロングパラメータ
   def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in, keys: %i(tcode))
+    devise_parameter_sanitizer.permit(:sign_in, keys: %i[tcode])
   end
 
   # schoolの特定
@@ -53,4 +54,12 @@ class Teachers::SessionsController < Devise::SessionsController
   #   end
   # end
 
+  private
+
+  def check_current_system_admin
+    if current_system_admin
+      flash[:danger] = '現在システム管理者でログイン中です。職員でログインする場合は一度ログアウトしてください。'
+      redirect_to system_admins_schools_url
+    end
+  end
 end


### PR DESCRIPTION
## 実装内容

タイトルの通りです。
職員でのログイン状態を保ちながらシステム管理者でもログイン可能なようでしたので調整しました。

## この実装により想定される動作

- システム管理者でログイン中に、職員のログイン画面を表示しようとした場合
  - 「現在システム管理者でログイン中です」というメッセージとともにシステム管理者のhomeへ遷移
- 職員でログイン中に、システム管理者のログイン画面を表示しようとした場合
  - 「現在職員でログイン中です」というメッセージとともに職員のhomeへ遷移

## システム管理者でログイン

https://user-images.githubusercontent.com/46830937/147246127-f823eda6-1a78-4a57-85c0-f88c40a92b51.mov

## 職員でログイン

https://user-images.githubusercontent.com/46830937/147245975-4652b73d-0870-44cf-8de0-47a99530942d.mov


