### PR TITLE
ビューの軽微な修正とアクセス制限追加

### DIFF
--- a/app/assets/stylesheets/alergy_checks.scss
+++ b/app/assets/stylesheets/alergy_checks.scss
@@ -21,9 +21,3 @@ table.table__alergy-contents--center > thead > tr > td {
     display: none;
   }
 }
-
-// 代理報告ページ
-.button__proxy--position {
-  margin-top: 10px;
-  margin-left: 28px;
-}

--- a/app/assets/stylesheets/charger_alergy_checks.scss
+++ b/app/assets/stylesheets/charger_alergy_checks.scss
@@ -1,0 +1,5 @@
+// 代理報告ページ
+.button__proxy--position {
+  margin-top: 10px;
+  margin-left: 28px;
+}

--- a/app/assets/stylesheets/creator_alergy_checks.scss
+++ b/app/assets/stylesheets/creator_alergy_checks.scss
@@ -4,3 +4,7 @@ table.table__creator-contents--center > thead > tr > th {
   text-align: center;
   vertical-align: middle;
 }
+
+.button__creator > .btn {
+  margin-bottom: 5px;
+}

--- a/app/controllers/admin_alergy_checks_controller.rb
+++ b/app/controllers/admin_alergy_checks_controller.rb
@@ -1,5 +1,6 @@
 class AdminAlergyChecksController < ApplicationController
     UPDATE_ERROR_MSG = "登録に失敗しました。やり直してください。"
+    before_action :admin_teacher, only: [:one_month_index]
     before_action :set_first_last_day
 
     def one_month_index

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -2,9 +2,9 @@ class AlergyChecksController < ApplicationController
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
   before_action :set_first_last_day, only: :one_month_index
   before_action :have_class_room, only: :one_month_index
+  before_action :set_submitted, only: [:show, :today_index]
 
   def show
-    @submitted = @classroom.alergy_checks.today.where.not(status: "").count #報告済み件数
     @alergy_check_sum = @classroom.alergy_checks.today.count
   end
 
@@ -61,6 +61,11 @@ class AlergyChecksController < ApplicationController
   end
 
   private
+    # 報告済件数取得
+    def set_submitted
+      @submitted = @classroom.alergy_checks.today.where.not(status: "").count
+    end
+
     # 代理報告か確認
     def proxy_report_check
       !!params[:proxy_flag]

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -1,7 +1,7 @@
 class AlergyChecksController < ApplicationController
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
   before_action :set_first_last_day, only: :one_month_index
-  before_action :have_class_room?, only: :one_month_index
+  before_action :have_class_room, only: :one_month_index
 
   def show
     @submitted = @classroom.alergy_checks.today.where.not(status: "").count #報告済み件数
@@ -84,7 +84,7 @@ class AlergyChecksController < ApplicationController
     end
 
     # クラスを持つ職員かどうかの判定
-    def have_class_room?
+    def have_class_room
       unless Classroom.exists?(current_teacher.classroom_id)
         flash[:danger] = "許可されていない操作です。"
         redirect_to show_teachers_path

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class CreatorAlergyChecksController < ApplicationController
+  before_action :creator_teacher
   before_action :set_first_last_day, only: :index
 
   def index
@@ -75,5 +76,13 @@ class CreatorAlergyChecksController < ApplicationController
   private
     def edit_creator_params
       params.require(:alergy_check).permit(:student_id, :menu, :support, :note)
+    end
+
+    # 対応法作成権限を持つ職員かどうかの判定
+    def creator_teacher
+      unless current_teacher.creator? || current_teacher.admin?
+        flash[:danger] = "アクセス権限がありません。"
+        redirect_to show_teachers_path
+      end
     end
 end

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -28,7 +28,7 @@ class CreatorAlergyChecksController < ApplicationController
         end
       end
     end
-    flash[:success] = 'アレルギー情報を登録しました。'
+    flash[:success] = '対応法を登録しました。'
     redirect_to teachers_creator_alergy_checks_url
 
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
@@ -63,7 +63,7 @@ class CreatorAlergyChecksController < ApplicationController
     @alergy_check = AlergyCheck.find(params[:id])
     @student = @alergy_check.student
     @alergy_check.destroy
-    flash[:success] = "#{l(@alergy_check.worked_on, format: :short)}、#{@student.student_name}の情報を削除しました。"
+    flash[:success] = "#{l(@alergy_check.worked_on, format: :short)}、#{@student.student_name}の対応法を削除しました。"
     redirect_to teachers_creator_alergy_checks_url
   end
 

--- a/app/helpers/alergy_checks_helper.rb
+++ b/app/helpers/alergy_checks_helper.rb
@@ -16,7 +16,7 @@ module AlergyChecksHelper
     end
   end
 
-  # 備考欄表示有無
+  # 備考欄空白の場合は「なし」表示」
   def note(note)
     if note.present?
       return note

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def full_title(page_name = "")
-      base_title = "AllergyCheckqApp"
+      base_title = "AllergyCheckApp"
     if page_name.empty?
       base_title
     else

--- a/app/views/admin_alergy_checks/one_month_index.html.erb
+++ b/app/views/admin_alergy_checks/one_month_index.html.erb
@@ -1,6 +1,7 @@
 <h1>全学級月間チェック一覧</h1>
 <div class="button__monthly">
   <%= link_to "前月", one_month_index_teachers_admin_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>
+  <%= link_to "当月", one_month_index_teachers_admin_alergy_checks_path, class: "btn btn-info" %>
   <%= link_to "次月", one_month_index_teachers_admin_alergy_checks_path(date: @first_day.next_month), class: "btn btn-info" %>
 </div>
 

--- a/app/views/alergy_checks/_today_index.html.erb
+++ b/app/views/alergy_checks/_today_index.html.erb
@@ -57,7 +57,11 @@
               <% end %>
             <% end %>
           </table>
-          <%= f.submit "報告する", class: "btn btn-block btn-primary" %>
+          <% if @alergy_checks.count == @submitted %>
+            <%= f.submit "報告する", disabled: true, class: "btn btn-block btn-primary" %>
+          <% else %>
+            <%= f.submit "報告する", class: "btn btn-block btn-primary" %>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/app/views/alergy_checks/one_month_index.html.erb
+++ b/app/views/alergy_checks/one_month_index.html.erb
@@ -1,6 +1,7 @@
 <h1><%= current_teacher.classroom.class_name %>月間チェック一覧</h1>
 <div class="button__monthly">
   <%= link_to "前月", one_month_index_teachers_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>
+  <%= link_to "当月", one_month_index_teachers_alergy_checks_path, class: "btn btn-info" %>
   <%= link_to "次月", one_month_index_teachers_alergy_checks_path(date: @first_day.next_month), class: "btn btn-info" %>
   <% if @alergy_checks.any? %>
     <%= link_to "印刷する", "#", class: "btn btn-primary", onclick: "window.print(); return false;" %>

--- a/app/views/alergy_checks/show.html.erb
+++ b/app/views/alergy_checks/show.html.erb
@@ -18,7 +18,7 @@
     <% if @alergy_check_sum > 0 %>
       <%= link_to "有", today_index_teachers_alergy_checks_path, remote: true, class: "inline-block button" %>
     <% else %>
-      <a class="inline-block button" href="#">無</a>
+      <span class="inline-block button">無</span>
     <% end %>
   </div>
 </div>

--- a/app/views/creator_alergy_checks/index.html.erb
+++ b/app/views/creator_alergy_checks/index.html.erb
@@ -1,13 +1,9 @@
-<div>
-  <table class="table table-bordered table-condensed user-table">
-    <tr>
-      <td>
-        <%= link_to "←", teachers_creator_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-primary" %>
-        <%= l(@first_day, format: :middle) %> 対応法詳細
-        <%= link_to "→", teachers_creator_alergy_checks_path(date: @first_day.next_month), class: "btn btn-primary" %>
-      </td>
-    </tr>
-  </table>
+<h1><%= l(@first_day, format: :middle) %> 対応法詳細</h1>
+
+<div class="button__creator">
+  <%= link_to "前月", teachers_creator_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>
+  <%= link_to "当月", teachers_creator_alergy_checks_path, class: "btn btn-info" %>
+  <%= link_to "次月", teachers_creator_alergy_checks_path(date: @first_day.next_month), class: "btn btn-info" %>
 </div>
 
 <div>

--- a/app/views/creator_alergy_checks/index.html.erb
+++ b/app/views/creator_alergy_checks/index.html.erb
@@ -52,7 +52,9 @@
                 <td><%= link_to "編集", edit_teachers_creator_alergy_check_path(alergy_check.id),
                         class: "btn btn-primary", remote: true %></td>
                 <td><%= link_to "削除", teachers_creator_alergy_check_path(alergy_check.id),
-                        method: :delete, data: { confirm: "対応法情報を削除します。よろしいですか？" }, class: "btn btn-danger" %></td>
+                        method: :delete, 
+                        data: { confirm: "#{l(alergy_check.worked_on, format: :short)}、#{student.student_name}の対応法を削除します。よろしいですか？" },
+                        class: "btn btn-danger" %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/layouts/_teacher_header.html.erb
+++ b/app/views/layouts/_teacher_header.html.erb
@@ -9,8 +9,8 @@
     <% if !current_teacher.charger? && Classroom.exists?(current_teacher.classroom_id) %>
       <li><%= link_to '月間チェック一覧', one_month_index_teachers_alergy_checks_path %></li>
     <% end %>
-    <li><%= link_to '全学級月間チェック一覧', one_month_index_teachers_admin_alergy_checks_path %></li>
     <% if current_teacher.admin? %>
+      <li><%= link_to '全学級月間チェック一覧', one_month_index_teachers_admin_alergy_checks_path %></li>
       <!--li><%= link_to '職員登録', new_teacher_registration_path %></li -->
       <li><%= link_to '職員一覧', classrooms_path %></li>
       <li><%= link_to 'クラス編集', edit_using_class_classrooms_path %></li>


### PR DESCRIPTION
【作業内容】
①対応法作成ページ周りのアクセス制限を追加。
②全学級月間チェック一覧ページのアクセス制限を追加。
③対応法作成ページにて、対応法削除時の確認メッセージを修正。
④担任ページの「無」ボタンを表示のみに変更。
⑤対応法作成ページ、月間チェック一覧ページ、全学級月間チェック一覧ページに「当月」ボタンを追加。
⑥チェック児童一覧ページにて、全てのチェック報告が完了した場合、報告するボタンをロックする。

【期待される動作】
①対応法作成権限を持つ職員 or 管理職しかアクセスできない。
②管理職しかアクセスできない。
③対応法削除時のメッセージに、削除しようとしている対応法の情報(日付と児童名)が表示される。
④作業内容の通り。
⑤当月ボタンクリックで、今月の情報を表示させる。
⑥報告するボタンがロックされ、クリックできない。

<img width="898" alt="スクリーンショット 2021-12-23 23 22 24" src="https://user-images.githubusercontent.com/63346413/147254640-2407f28a-d96a-40c1-9712-fa015b4556e5.png">
<img width="1191" alt="スクリーンショット 2021-12-23 23 22 44" src="https://user-images.githubusercontent.com/63346413/147254650-28593767-4dc8-416e-a546-a3b451c25f15.png">
<img width="1184" alt="スクリーンショット 2021-12-23 23 23 01" src="https://user-images.githubusercontent.com/63346413/147254654-0c34d4f6-3a8d-4860-a54d-e3a337c89f76.png">
<img width="1180" alt="スクリーンショット 2021-12-23 23 23 37" src="https://user-images.githubusercontent.com/63346413/147254656-d62f4ab0-c976-4ac9-8495-5d757bb100bc.png">
<img width="1207" alt="スクリーンショット 2021-12-23 23 29 59" src="https://user-images.githubusercontent.com/63346413/147254658-d2f872c7-3fbb-4902-9b1f-b24d8948fa31.png">
<img width="478" alt="スクリーンショット 2021-12-23 23 31 43" src="https://user-images.githubusercontent.com/63346413/147254661-39d9ed45-9dc2-4a87-9e24-eeca42e90168.png">


【共有事項】
アクセス制限は以下が未実装です。
・本日の作業選択、自クラス報告、対応法作成、全学級月間チェック一覧、代理報告、月間チェック一覧→システム管理者はアクセスできない
・代理報告ページ→charger: true or admin: trueのユーザーでないとアクセスできないこと