### PR TITLE
アクセス制限の追加

### DIFF
--- a/app/controllers/admin_alergy_checks_controller.rb
+++ b/app/controllers/admin_alergy_checks_controller.rb
@@ -3,6 +3,7 @@ class AdminAlergyChecksController < ApplicationController
     include AjaxHelper
     UPDATE_ERROR_MSG = "登録に失敗しました。やり直してください。"
 
+    before_action :system_admin_inaccessible
     before_action :set_school
     before_action :admin_teacher, only: [:one_month_index]
     before_action :set_first_last_day

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class AlergyChecksController < ApplicationController
+  before_action :system_admin_inaccessible
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
   before_action :set_first_last_day, only: :one_month_index
   before_action :have_class_room, only: :one_month_index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,7 @@ class ApplicationController < ActionController::Base
     if current_system_admin
       case controller_name
       when "alergy_checks", "charger_alergy_checks", "creator_alergy_checks", \
-            "admin_alergy_checks", "teachers", "classrooms", "menus", "school_students"
+            "admin_alergy_checks", "teachers", "classrooms", "menus", "school_students", "registrations"
         flash[:danger] = ACCESS_ERROR_MSG
         redirect_to system_admins_schools_path
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   # ---------下記既存アプリの記述-------------------
   # ページ出力前に1ヶ月分のデータの存在を確認・セットします。
- def set_one_month
+  def set_one_month
   @first_day = params[:date].nil? ?
   Date.current.beginning_of_month : params[:date].to_date
   @last_day = @first_day.end_of_month
@@ -50,7 +50,8 @@ class ApplicationController < ActionController::Base
   def system_admin_inaccessible
     if current_system_admin
       case controller_name
-      when "alergy_checks", "charger_alergy_checks", "creator_alergy_checks", "admin_alergy_checks", "teachers"
+      when "alergy_checks", "charger_alergy_checks", "creator_alergy_checks", \
+            "admin_alergy_checks", "teachers", "classrooms", "menus", "school_students"
         flash[:danger] = ACCESS_ERROR_MSG
         redirect_to system_admins_schools_path
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   include SessionsHelper
   $days_of_the_week = %w{日 月 火 水 木 金 土}
+  ACCESS_ERROR_MSG = "アクセス権限がありません。"
 
   # ---------下記既存アプリの記述-------------------
   # ページ出力前に1ヶ月分のデータの存在を確認・セットします。
@@ -42,7 +43,18 @@ class ApplicationController < ActionController::Base
 
   # 管理者かどうかの判定
   def admin_teacher
-    redirect_to show_teachers_path, flash: { danger: "権限がありません。" } unless current_teacher.admin?
+    redirect_to show_teachers_path, flash: { danger: ACCESS_ERROR_MSG } unless current_teacher.admin?
+  end
+
+  # システム管理者がアクセスできるページかの判定
+  def system_admin_inaccessible
+    if current_system_admin
+      case controller_name
+      when "alergy_checks", "charger_alergy_checks", "creator_alergy_checks", "admin_alergy_checks", "teachers"
+        flash[:danger] = ACCESS_ERROR_MSG
+        redirect_to system_admins_schools_path
+      end
+    end
   end
 
   # 今日の日付からその月の初日と最終日を取得

--- a/app/controllers/charger_alergy_checks_controller.rb
+++ b/app/controllers/charger_alergy_checks_controller.rb
@@ -1,8 +1,18 @@
 class ChargerAlergyChecksController < ApplicationController
+  before_action :system_admin_inaccessible
+  before_action :charger_teacher
 
   def show
     # ログインしている職員の学校内で、本日チェックが必要なアレルギー情報を抽出
     @classrooms = Classroom.includes(students: :alergy_checks).where(school_id: current_teacher.school.id, alergy_checks: {worked_on: Date.current})
   end
 
+  private
+    # 代理報告権限を持つ職員かどうかの判定
+    def charger_teacher
+      unless current_teacher.charger? || current_teacher.admin?
+        flash[:danger] = "アクセス権限がありません。"
+        redirect_to show_teachers_path
+      end
+    end
 end

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -1,6 +1,7 @@
 class ClassroomsController < ApplicationController
   include SchoolsHelper
 
+  before_action :system_admin_inaccessible
   before_action :set_school
   before_action :authenticate_teacher!
   before_action :admin_teacher, only: [:index, :edit_using_class, :update_using_class]

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class CreatorAlergyChecksController < ApplicationController
+  before_action :system_admin_inaccessible
   before_action :creator_teacher
   before_action :set_first_last_day, only: :index
 

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,6 +1,7 @@
 class MenusController < ApplicationController
   include SchoolsHelper
 
+  before_action :system_admin_inaccessible
   before_action :set_school
   before_action :set_menu, only: [:show, :edit, :update, :destroy]
   before_action :admin_teacher, only: [:new, :create, :edit, :update, :destroy]

--- a/app/controllers/school_students_controller.rb
+++ b/app/controllers/school_students_controller.rb
@@ -1,6 +1,7 @@
 class SchoolStudentsController < ApplicationController
   include SchoolsHelper
 
+  before_action :system_admin_inaccessible
   before_action :set_school
   before_action :set_school_student, only: [:edit, :update, :destroy]
   before_action :admin_teacher, only: [:new, :create, :edit, :update, :destroy]

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -2,6 +2,7 @@
 # 下記アクションの内、結局editしか使っていない状況（12/16）
 
 class Teachers::RegistrationsController < Devise::RegistrationsController
+  prepend_before_action :system_admin_inaccessible, only: [:edit]
   prepend_before_action :require_no_authentication, only: [:cancel] # ログイン後も新規登録を可能にする為、new、createを外す
   before_action :creatable?, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -2,8 +2,8 @@
 # 下記アクションの内、結局editしか使っていない状況（12/16）
 
 class Teachers::RegistrationsController < Devise::RegistrationsController
-  prepend_before_action :system_admin_inaccessible, only: [:edit]
   prepend_before_action :require_no_authentication, only: [:cancel] # ログイン後も新規登録を可能にする為、new、createを外す
+  prepend_before_action :system_admin_inaccessible
   before_action :creatable?, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,6 +1,6 @@
 class TeachersController < ApplicationController
   include SchoolsHelper
-
+  before_action :system_admin_inaccessible
   before_action :authenticate_teacher!
   before_action :admin_teacher, only: [:new, :create, :edit_info, :update_info, :destroy]
 


### PR DESCRIPTION
【作業内容】
①各学校ページ用のコントローラ(admin_alergy_checks、alergy_checks、charger_alergy_checks、classrooms、creator_alergy_checks、menu、school_students、teachers)に、システム管理者がログインしている場合学校一覧ページにリダイレクトするbefore_actionを追加。
②charger_alrgy_checksコントローラに、管理者もしくは代理報告権限を持つ職員でなければ、本日の作業選択ページにリダイレクトするbefore_actionを追加。
【期待される動作】
①システム管理者は、各学校のページ全てにアクセスできない。
②代理報告ページには、管理者もしくは代理報告権限を持つ職員しかアクセスできない。

【その他共有事項】
・authenticate_teacher!メソッド(ログインしている職員しかアクセスできないようにする)を使用しているコントローラのビューに関して、修正が必要と思われる箇所がありました。
URL直打ちでページにアクセスした場合、
authenticate_teacher!メソッドを使用しているビューだと
current_teacherが存在しないためログイン画面にリダイレクトする→ログイン画面のURLに必要な値(:school_url)がないため、以下のようなエラーになります
<img width="1036" alt="スクリーンショット 2021-12-25 16 30 44" src="https://user-images.githubusercontent.com/63346413/147380287-64421b77-646d-4ece-be12-d2e9ac2dc9c5.png">

また、authenticate_teacher!メソッドをまだ追加していないコントローラもあり、それらのビューは
ページによって内容は異なりますが、現状以下のようなエラーが出る状態です(一例として自クラス報告ページにアクセスした場合のエラーです)
<img width="1018" alt="スクリーンショット 2021-12-25 16 53 13" src="https://user-images.githubusercontent.com/63346413/147380332-083cd14a-a796-4ec1-8f8d-4dbbb9858358.png">