### PR TITLE
チェック児童一覧モーダルの動作を調整

### DIFF
--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -10,6 +10,7 @@ class AlergyChecksController < ApplicationController
 
   def today_index
     @alergy_checks = @classroom.alergy_checks.today.order(:student_id)
+    @unreported_alergy_checks_ids = @classroom.alergy_checks.today.unreported.pluck(:id)
     @teachers = Teacher.where(school_id: current_teacher.school_id) # 代理報告時に選択
   end
 

--- a/app/models/alergy_check.rb
+++ b/app/models/alergy_check.rb
@@ -37,4 +37,5 @@ class AlergyCheck < ApplicationRecord
 
   # worked_onカラムが本日の日付であるものを取得する
   scope :today, -> { where(worked_on: Date.current) }
+  scope :unreported, -> { where(status: "") }
 end

--- a/app/views/alergy_checks/_today_index.html.erb
+++ b/app/views/alergy_checks/_today_index.html.erb
@@ -7,7 +7,7 @@
       <h1>【チェック児童一覧】</h1>
 
       <div class="modal-body">
-      <%= form_with(url: teachers_alergy_checks_path, local: true, method: :patch) do |f| %>
+      <%= form_with(url: teachers_alergy_checks_path, local: true, method: :patch, id: "allergy-check-form") do |f| %>
         <table width=100%, class="table table-bordered table-condensed table__alergy-contents--center ">
           <thead>
             <tr>
@@ -58,12 +58,48 @@
             <% end %>
           </table>
           <% if @alergy_checks.count == @submitted %>
-            <%= f.submit "報告する", disabled: true, class: "btn btn-block btn-primary" %>
+            <%= f.submit "報告済み", disabled: true, class: "btn btn-block btn-primary" %>
           <% else %>
-            <%= f.submit "報告する", class: "btn btn-block btn-primary" %>
+            <%= f.submit "チェックを入れた行を報告する", type: "button", class: "btn btn-block btn-primary", onclick: "submitForm();" %>
           <% end %>
         <% end %>
       </div>
     </div>
   </div>
 </div>
+
+<script>
+  function submitForm() {
+    let ids = <%= @unreported_alergy_checks_ids %>;
+    let result = true;
+    for (let i = 0; i < ids.length; i++) {
+      let id = ids[i];
+      let check = isCorrectCheck(id);
+      if (check === false) {
+        alert('報告する場合は第1チェック、第2チェック、本人チェックの3つ全てにチェックを入れる必要があります。');
+        result = false;
+        break;
+      }
+    }
+    if (result === true) {
+      $('#allergy-check-form').submit();
+    }
+  }
+
+  function isCorrectCheck(id) {
+    let count = 0;
+    if ($(`#_alergy_checks_${id}_first_check`).is(':checked') === true) {
+      count += 1;
+    }
+    if ($(`#_alergy_checks_${id}_second_check`).is(':checked') === true) {
+      count += 1;
+    }
+    if ($(`#_alergy_checks_${id}_student_check`).is(':checked') === true) {
+      count += 1;
+    }
+    if (count === 1 || count === 2) {
+      return false;
+    }
+    return true;
+  }
+</script>


### PR DESCRIPTION
中村さんが担当予定だったタスクを実装しました。

### 実現したこと

- チェック児童一覧モーダルで「第1チェック」「第2チェック」「本人チェック」の3つのチェックが揃っていないと更新できないこと
  - 中途半端に1個または2個だけチェックが入っている行がある場合は、submitボタン押下でalertを表示

https://user-images.githubusercontent.com/46830937/147385639-1bbd458d-62dc-445a-98ce-35c4a81d0c48.mov
 

### 未実装

〜validationメッセージをモーダル内で表示する〜

今回上記タスクは実装していません。

今回の作業により
「報告に失敗たチェックが#{@unupdated}件あります。チェック内容を確認してください」
と表示される場面はおそらく無くなったと思われます。
改めて検討の上、必要であれば別タスクとして実装をお願いします。

### 欲を言えば

チェックを一つも入れていない場合にはsubmitボタンを押せなくしても良さそうだなと思いましたが、一旦ここまでの内容でPRをあげさせていただきます。