### PR TITLE
Fix admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
     when SystemAdmin
       system_admins_schools_path
     when Teacher
-      if current_teacher.admin == true && resource.sign_in_count == 1 && current_teacher.school.first_edit == false
+      if current_teacher.admin && resource.sign_in_count == 1 && !current_teacher.school.first_edit
         edit_using_class_classrooms_path
       else
         show_teachers_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     when SystemAdmin
       system_admins_schools_path
     when Teacher
-      if current_teacher.admin == true && resource.sign_in_count == 1
+      if current_teacher.admin == true && resource.sign_in_count == 1 && current_teacher.school.first_edit == false
         edit_using_class_classrooms_path
       else
         show_teachers_path

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -24,23 +24,38 @@ class ClassroomsController < ApplicationController
 
   def update_using_class
     @classrooms = @school.classrooms.all.order(:id)
-    ActiveRecord::Base.transaction do
-      using_class_params.each do |id, item|
-        if item[:class_name].blank?
-          flash[:danger] = "クラス名を入力して下さい"
-          redirect_to edit_using_class_classrooms_path(@school)
-        else
-          classroom = Classroom.find(id)
-          classroom.update_attributes!(item)
-        end
+    using_class_params.each do |id, item|
+      classroom = Classroom.find(id)
+      if classroom.update_attributes!(item)
+        @school.update(first_edit: true)
+        flash[:success] = "クラス編集を更新しました。"
+        redirect_to classrooms_path and return
+      else
+        flash[:danger] = "更新に失敗しました。<br>・#{classroom.errors.full_messages.join('<br>・')}"
+        render :edit_using_class
       end
     end
-    flash[:success] = "クラス編集を更新しました。"
-    redirect_to classrooms_path
-  rescue ActiveRecord::RecordInvalid
-    flash[:danger] = "無効な入力データがあった為、更新をキャンセルしました。"
-    redirect_to edit_using_class_classrooms_path(@school)
   end
+
+
+  #   ActiveRecord::Base.transaction do
+  #     using_class_params.each do |id, item|
+  #       if item[:class_name].blank?
+  #         flash[:danger] = "クラス名を入力して下さい"
+  #         redirect_to edit_using_class_classrooms_path(@school)
+  #       else
+  #         classroom = Classroom.find(id)
+  #         classroom.update_attributes!(item)
+  #       end
+  #     end
+  #   end
+  #   flash[:success] = "クラス編集を更新しました。"
+  #   @school.first_edit = true
+  #   redirect_to classrooms_path
+  # rescue ActiveRecord::RecordInvalid
+  #   flash[:danger] = "無効な入力データがあった為、更新をキャンセルしました。"
+  #   redirect_to edit_using_class_classrooms_path(@school)
+  # end
 
 private
 

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -27,7 +27,7 @@ class ClassroomsController < ApplicationController
     @classrooms = @school.classrooms.all.order(:id)
     using_class_params.each do |id, item|
       classroom = Classroom.find(id)
-      if classroom.update_attributes!(item)
+      if classroom.update_attributes(item)
         @school.update(first_edit: true)
         flash[:success] = "クラス編集を更新しました。"
         redirect_to classrooms_path and return
@@ -37,26 +37,6 @@ class ClassroomsController < ApplicationController
       end
     end
   end
-
-
-  #   ActiveRecord::Base.transaction do
-  #     using_class_params.each do |id, item|
-  #       if item[:class_name].blank?
-  #         flash[:danger] = "クラス名を入力して下さい"
-  #         redirect_to edit_using_class_classrooms_path(@school)
-  #       else
-  #         classroom = Classroom.find(id)
-  #         classroom.update_attributes!(item)
-  #       end
-  #     end
-  #   end
-  #   flash[:success] = "クラス編集を更新しました。"
-  #   @school.first_edit = true
-  #   redirect_to classrooms_path
-  # rescue ActiveRecord::RecordInvalid
-  #   flash[:danger] = "無効な入力データがあった為、更新をキャンセルしました。"
-  #   redirect_to edit_using_class_classrooms_path(@school)
-  # end
 
 private
 

--- a/app/controllers/teachers/passwords_controller.rb
+++ b/app/controllers/teachers/passwords_controller.rb
@@ -9,19 +9,45 @@ class Teachers::PasswordsController < Devise::PasswordsController
   # end
 
   # POST /resource/password
-  # def create
-  #   super
-  # end
+  def create
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+    else
+      respond_with(resource)
+    end
+  end
 
   # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+  def edit
+    self.resource = resource_class.new
+    set_minimum_password_length
+    resource.reset_password_token = params[:reset_password_token]
+  end
 
   # PUT /resource/password
-  # def update
-  #   super
-  # end
+  def update
+    self.resource = resource_class.reset_password_by_token(resource_params)
+    yield resource if block_given?
+
+    if resource.errors.empty?
+      resource.unlock_access! if unlockable?(resource)
+      if Devise.sign_in_after_reset_password
+        flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
+        set_flash_message!(:notice, flash_message)
+        resource.after_database_authentication
+        sign_in(resource_name, resource)
+      else
+        set_flash_message!(:notice, :updated_not_active)
+      end
+      respond_with resource, location: after_resetting_password_path_for(resource)
+    else
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
 
   # protected
 

--- a/app/controllers/teachers/passwords_controller.rb
+++ b/app/controllers/teachers/passwords_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Teachers::PasswordsController < Devise::PasswordsController
-  before_action :set_school
-
   # GET /resource/password/new
   # def new
   #   super
@@ -51,11 +49,6 @@ class Teachers::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  # schoolの特定
-  def set_school
-    @school = School.find_by!(school_url: params[:school_url])
-  end
-  
 
   # def after_resetting_password_path_for(resource)
   #   super(resource)

--- a/app/controllers/teachers/passwords_controller.rb
+++ b/app/controllers/teachers/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Teachers::PasswordsController < Devise::PasswordsController
+  before_action :set_school
+
   # GET /resource/password/new
   # def new
   #   super
@@ -22,6 +24,12 @@ class Teachers::PasswordsController < Devise::PasswordsController
   # end
 
   # protected
+
+  # schoolの特定
+  def set_school
+    @school = School.find_by!(school_url: params[:school_url])
+  end
+  
 
   # def after_resetting_password_path_for(resource)
   #   super(resource)

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -31,9 +31,9 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    @classrooms = current_teacher.school.classrooms.where(using_class: true).order(:id)
+  end
 
   # DELETE /resource
   # def destroy

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -30,7 +30,7 @@ class TeachersController < ApplicationController
   def update_info
     @teacher = current_school.teachers.find(params[:teacher][:id])
     if @teacher.update_attributes(teachers_params)
-      flash[:success] = "職員情報を更新しました。"
+      flash[:success] = "#{@teacher.teacher_name}の情報を更新しました。"
     else
       flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"
     end

--- a/app/views/teachers/mailer/reset_password_instructions.html.erb
+++ b/app/views/teachers/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, school_url: @resource.school.school_url, reset_password_token: @token) %></p>
 
 <p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>

--- a/app/views/teachers/mailer/reset_password_instructions.html.erb
+++ b/app/views/teachers/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token, school_url: @school.id) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>

--- a/app/views/teachers/mailer/reset_password_instructions.html.erb
+++ b/app/views/teachers/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token, school_url: @school.id) %></p>
 
 <p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>

--- a/app/views/teachers/passwords/edit.html.erb
+++ b/app/views/teachers/passwords/edit.html.erb
@@ -3,6 +3,8 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
+  <!-- %= f.hidden_field_tag :school_url, value: params[:school_url] % -->
+  <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
 
   <div class="form-group">
     <%= f.label :password, t('.new_password') %>

--- a/app/views/teachers/passwords/edit.html.erb
+++ b/app/views/teachers/passwords/edit.html.erb
@@ -3,8 +3,6 @@
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
   <%= f.hidden_field :reset_password_token %>
-  <!-- %= f.hidden_field_tag :school_url, value: params[:school_url] % -->
-  <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
 
   <div class="form-group">
     <%= f.label :password, t('.new_password') %>

--- a/app/views/teachers/passwords/new.html.erb
+++ b/app/views/teachers/passwords/new.html.erb
@@ -1,7 +1,9 @@
 <h1><%= "パスワードの再設定" %></h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: teacher_password_path, html: { method: :post }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
+  <!-- %= hidden_field_tag :school_url, params[:school_url] % -->
+  <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
 
   <div class="form-group">
     <%= f.label :email %>

--- a/app/views/teachers/passwords/new.html.erb
+++ b/app/views/teachers/passwords/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for(resource, as: resource_name, url: teacher_password_path, html: { method: :post }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-  <!-- %= hidden_field_tag :school_url, params[:school_url] % -->
+  <!-- %= f.hidden_field_tag :school_url, value: params[:school_url] % -->
   <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
 
   <div class="form-group">

--- a/app/views/teachers/passwords/new.html.erb
+++ b/app/views/teachers/passwords/new.html.erb
@@ -2,8 +2,6 @@
 
 <%= form_for(resource, as: resource_name, url: teacher_password_path, html: { method: :post }) do |f| %>
   <%= bootstrap_devise_error_messages! %>
-  <!-- %= f.hidden_field_tag :school_url, value: params[:school_url] % -->
-  <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
 
   <div class="form-group">
     <%= f.label :email %>
@@ -15,4 +13,6 @@
   </div>
 <% end %>
 
-<%= render 'teachers/shared/links' %>
+<%= link_to '戻る', new_teacher_session_path(school_url: params[:school_url]), class: 'btn btn-default btn-block' %>
+
+<!-- %= render 'teachers/shared/links' %-->

--- a/app/views/teachers/sessions/new.html.erb
+++ b/app/views/teachers/sessions/new.html.erb
@@ -27,4 +27,4 @@
   </div>
 <% end %>
 
-<!-- %= render 'teachers/shared/links' % -->
+<%= render 'teachers/shared/links' %>

--- a/app/views/teachers/shared/_links.html.erb
+++ b/app/views/teachers/shared/_links.html.erb
@@ -1,15 +1,15 @@
 <hr class="border-dark my-5">
 <div class="form-group">
-  <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name, school_url: params[:school_url]), class: 'btn btn-primary btn-block' %><br />
-  <% end -%>
+  <!-- %- if controller_name != 'sessions' %-->
+    <!--%= link_to t(".sign_in"), new_session_path(resource_name, school_url: params[:school_url]), class: 'btn btn-primary btn-block' %><br /-->
+  <!--% end -%-->
 
   <!-- %- if devise_mapping.registerable? && controller_name != 'registrations' % -->
     <!--%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br /-->
   <!--% end -%-->
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name, school_url: params[:school_url]), class: 'btn btn-default btn-block' %><br />
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-default btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/teachers/shared/_links.html.erb
+++ b/app/views/teachers/shared/_links.html.erb
@@ -1,15 +1,15 @@
 <hr class="border-dark my-5">
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-primary btn-block' %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name, school_url: params[:school_url]), class: 'btn btn-primary btn-block' %><br />
   <% end -%>
 
-  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br />
-  <% end -%>
+  <!-- %- if devise_mapping.registerable? && controller_name != 'registrations' % -->
+    <!--%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br /-->
+  <!--% end -%-->
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-default btn-block' %><br />
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name, school_url: params[:school_url]), class: 'btn btn-default btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/teachers/shared/_links.html.erb
+++ b/app/views/teachers/shared/_links.html.erb
@@ -1,12 +1,5 @@
 <hr class="border-dark my-5">
 <div class="form-group">
-  <!-- %- if controller_name != 'sessions' %-->
-    <!--%= link_to t(".sign_in"), new_session_path(resource_name, school_url: params[:school_url]), class: 'btn btn-primary btn-block' %><br /-->
-  <!--% end -%-->
-
-  <!-- %- if devise_mapping.registerable? && controller_name != 'registrations' % -->
-    <!--%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br /-->
-  <!--% end -%-->
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-default btn-block' %><br />

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,22 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = false
+
+  host = "#{ENV['HEROKU_APPNAME']}.herokuapp.com"
+  mail = ENV['GMAIL_ADDRESS']
+  pass = ENV['GOOGLE_PASS']
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+      address:              'smtp.gmail.com',
+      enable_starttls_auto: true,
+      port:                 587,
+      domain:               'gmail.com',
+      user_name:            mail,
+      password:             pass,
+      authentication:       :plain
+    }  
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,14 +72,14 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: host, protocol: 'https' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-      address:              'smtp.gmail.com',
-      enable_starttls_auto: true,
-      port:                 587,
-      domain:               'gmail.com',
-      user_name:            mail,
-      password:             pass,
-      authentication:       :plain
-    }  
+    address:              'smtp.gmail.com',
+    enable_starttls_auto: true,
+    port:                 587,
+    domain:               'gmail.com',
+    user_name:            mail,
+    password:             pass,
+    authentication:       :plain
+  }  
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'allergychecker9@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  
-  
 
   root 'static_pages#top'
 
@@ -30,7 +28,7 @@ Rails.application.routes.draw do
       get 'teachers/password/new', to: 'teachers/passwords#new', as: :new_teacher_password
       post 'teachers/password', to: 'teachers/passwords#create', as: :teacher_password
       get 'teachers/password/edit', to: 'teachers/passwords#edit', as: :edit_teacher_password
-      patch 'teachers/password', to: 'teachers/passwords#update', as: :update_teacher_password
+      put 'teachers/password', to: 'teachers/passwords#update', as: :update_teacher_password
     end
   end
   devise_scope :teacher do
@@ -51,7 +49,7 @@ Rails.application.routes.draw do
         get 'one_month_index'
         get 'lunch_check'
         patch 'update_lunch_check'
-      end   
+      end
       member do
         get 'lunch_check_info'
         patch 'update_lunch_check_info'
@@ -96,15 +94,15 @@ Rails.application.routes.draw do
 
   resource :teachers do
     resources :admin_alergy_checks, only: [:show] do
-      collection do  
+      collection do
         get 'lunch_check'
         patch 'update_lunch_check'
-      end   
+      end
       member do
         get 'lunch_check_info'
         patch 'update_lunch_check_info'
         get 'lunch_check_all'
-        patch 'update_lunch_check_all' 
+        patch 'update_lunch_check_all'
       end #collection do end
     end #resouces do end
   end #teachers do end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,7 @@ Rails.application.routes.draw do
 
 
   # 先生画面
-  devise_for :teachers, skip: 'sessions', controllers: {
-    passwords:     'teachers/passwords',
+  devise_for :teachers, skip: [:sessions, :passwords], controllers: {
     registrations: 'teachers/registrations',
     # omniauth_callbacks: "teachers/omniauth_callbacks"
   }
@@ -28,6 +27,10 @@ Rails.application.routes.draw do
     devise_scope :teacher do
       get 'teachers/sign_in', to: 'teachers/sessions#new', as: :new_teacher_session
       post 'teachers/sign_in', to: 'teachers/sessions#create', as: :teacher_session
+      get 'teachers/password/new', to: 'teachers/passwords#new', as: :new_teacher_password
+      post 'teachers/password', to: 'teachers/passwords#create', as: :teacher_password
+      get 'teachers/password/edit', to: 'teachers/passwords#edit', as: :edit_teacher_password
+      patch 'teachers/password', to: 'teachers/passwords#update', as: :update_teacher_password
     end
   end
   devise_scope :teacher do

--- a/db/migrate/20211218133253_add_first_edit_to_schools.rb
+++ b/db/migrate/20211218133253_add_first_edit_to_schools.rb
@@ -1,0 +1,5 @@
+class AddFirstEditToSchools < ActiveRecord::Migration[5.1]
+  def change
+    add_column :schools, :first_edit, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20211201110653) do
+ActiveRecord::Schema.define(version: 20211218133253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 20211201110653) do
     t.string "school_url", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "first_edit", default: false, null: false
   end
 
   create_table "students", force: :cascade do |t|


### PR DESCRIPTION
### 実装した事
１、初回作成の学校管理者と、2人目以降の学校管理者の初回ログイン後の遷移先を変更
　→schoolテーブルに`first_edit`というbooleanカラムを設け、クラス編集ページでの更新後にtrueになるよう設定
　→学校管理者ログイン後の遷移先の条件分岐にて、**`first_edit`がfalse→クラス編集ページ**、**true→本日の作業選択ページ**に遷移

２、システム管理者・学校管理者のパスワード再設定機能追加

### 上記実装で期待される動作
１、学校管理者の誰かがクラス編集ページにて一度でも更新作業を行なっていれば、その後に初回ログインする学校管理者のログイン後の遷移先は本日の作業選択ページとなる

２、システム管理者・学校管理者共に、ログイン画面の「パスワードを忘れましたか？」リンクからパスワード再設定方法のメール送信が行え、受信したメールより、「パスワード変更」リンクに飛び、パスワードの変更が行える事

### 補足
上記２の動作確認について
【開発環境】：メール送信後は、http://localhost:3000/letter_opener/ にアクセスする事で受信メールの確認が可能
【本番環境】：メールアドレス宛に直接メールが届きます

### 12/26修正追加し再プルリク
コメント頂いた分を修正して出し直しました