### PR TITLE
モーダル内エラーメッセージ表示機能追加、未ログイン時の各学校ページアクセス対策

### DIFF
--- a/app/controllers/admin_alergy_checks_controller.rb
+++ b/app/controllers/admin_alergy_checks_controller.rb
@@ -3,6 +3,7 @@ class AdminAlergyChecksController < ApplicationController
     include AjaxHelper
     UPDATE_ERROR_MSG = "登録に失敗しました。やり直してください。"
 
+    before_action :signed_in_teacher
     before_action :system_admin_inaccessible
     before_action :set_school
     before_action :admin_teacher, only: [:one_month_index]
@@ -18,7 +19,7 @@ class AdminAlergyChecksController < ApplicationController
     def show
       @teacher = current_teacher #Teacher.find(params[:id])
       @approval = AlergyCheck.joins({student: {classroom: :school}})
-                             .where(:schools =>{:id => current_teacher.school_id}, worked_on: Date.current, status: "確認済").count #報告済み件数
+                              .where(:schools =>{:id => current_teacher.school_id}, worked_on: Date.current, status: "確認済").count #報告済み件数
       @lunch_check_sum = AlergyCheck.joins({student: {classroom: :school}})
                                     .where(:schools =>{:id => current_teacher.school_id}, worked_on: Date.current).count
       @lunch_check_rest = @lunch_check_sum - @approval
@@ -27,39 +28,39 @@ class AdminAlergyChecksController < ApplicationController
 
     def lunch_check_info
       @requesters = AlergyCheck.joins({student: {classroom: :school}})
-                               .where(:schools =>{:id => current_teacher.school_id}, worked_on: Date.current)
-                               .select("alergy_checks.*, students.classroom_id").group_by{|record|record.classroom_id}
+                                .where(:schools =>{:id => current_teacher.school_id}, worked_on: Date.current)
+                                .select("alergy_checks.*, students.classroom_id").group_by{|record|record.classroom_id}
 
     end
 
     def update_lunch_check_info
       @user = current_teacher #Teacher.find(params[:id])
       ActiveRecord::Base.transaction do
-       lunch_check_info_params.each do |id, item|
-         if item['status_checker'] == "1" && item['status'] == "確認済"
+      lunch_check_info_params.each do |id, item|
+        if item['status_checker'] == "1" && item['status'] == "確認済"
           attendance = AlergyCheck.find(id)
           attendance.admin_name = @user.teacher_name
           attendance.update_attributes!(admin_name: @user.teacher_name)
           attendance.update_attributes!(item)
-           @info_sum = AlergyCheck.where(worked_on: Date.current, status: "確認済").count
-           @unapproval_info_sum = AlergyCheck.where(worked_on: Date.current, status: "要再確認").count
-           flash[:success] = "確認済#{@info_sum}件、要再確認#{@unapproval_info_sum}件"
-         elsif item['status_checker'] == "1" && item['status'] == "要再確認"
+          @info_sum = AlergyCheck.where(worked_on: Date.current, status: "確認済").count
+          @unapproval_info_sum = AlergyCheck.where(worked_on: Date.current, status: "要再確認").count
+          flash[:success] = "確認済#{@info_sum}件、要再確認#{@unapproval_info_sum}件"
+        elsif item['status_checker'] == "1" && item['status'] == "要再確認"
           attendance = AlergyCheck.find(id)
           attendance.admin_name = @user.teacher_name
           attendance.update_attributes!(admin_name: @user.teacher_name)
           attendance.update_attributes!(item)
-           @info_sum = AlergyCheck.where(worked_on: Date.current, status: "確認済").count
-           @unapproval_info_sum = AlergyCheck.where(worked_on: Date.current, status: "要再確認").count
-           flash[:success] = "確認済#{@info_sum}件、要再確認#{@unapproval_info_sum}件"
-         elsif item['status_checker'] == "1" && item['status'] == "報告中"
-           flash[:danger] = "正しく選択されていない件名があります"
-         elsif item['status_checker'] == "0" && item['status'] == "確認済"
-           flash[:danger] = "正しく選択されていない件名があります"
+          @info_sum = AlergyCheck.where(worked_on: Date.current, status: "確認済").count
+          @unapproval_info_sum = AlergyCheck.where(worked_on: Date.current, status: "要再確認").count
+          flash[:success] = "確認済#{@info_sum}件、要再確認#{@unapproval_info_sum}件"
+        elsif item['status_checker'] == "1" && item['status'] == "報告中"
+          flash[:danger] = "正しく選択されていない件名があります"
+        elsif item['status_checker'] == "0" && item['status'] == "確認済"
+          flash[:danger] = "正しく選択されていない件名があります"
         end #if end
-       end #each end
-       redirect_to teachers_admin_alergy_checks_url
-     end #Acctive do end
+      end #each end
+      redirect_to teachers_admin_alergy_checks_url
+    end #Acctive do end
     #def end
     rescue ActiveRecord::RecordInvalid # トランザクションによるエラーの分岐です。
       flash[:danger] = "無効な入力データがあった為、更新をキャンセルしました。"
@@ -78,5 +79,5 @@ private
 
     def lunch_check_info_params
       params.permit(attendances: [:status, :status_checker])[:attendances].merge(admin_name: current_teacher.teacher_name)
-     end
+    end
   end

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class AlergyChecksController < ApplicationController
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :set_classroom, only: [:show, :today_index, :one_month_index]
   before_action :set_first_last_day, only: :one_month_index

--- a/app/controllers/alergy_checks_controller.rb
+++ b/app/controllers/alergy_checks_controller.rb
@@ -16,9 +16,13 @@ class AlergyChecksController < ApplicationController
   end
 
   def update
-    @updated = 0
-    @unupdated = 0
-    if today_check_params.present?
+    updated = 0
+    unupdated = 0
+    # 報告なしならリダイレクト
+    if today_check_params.nil?
+      # 代理報告か否かでリダイレクト先を分岐
+      checked_redirect
+    else
       today_check_params.each do |id, checks|
         # 全てのチェックが入っているレコードの場合
         if checks[:first_check].present? && checks[:second_check].present? && checks[:student_check].present?
@@ -26,7 +30,6 @@ class AlergyChecksController < ApplicationController
           # 同じschool_idを持つ児童でないと報告できない
           if current_teacher.school.id != alergy_check.student.school_id
             flash[:danger] = "許可されていない操作が行われました。"
-            # 代理報告か否かでリダイレクト先を分岐
             checked_redirect
           end
 
@@ -35,26 +38,31 @@ class AlergyChecksController < ApplicationController
           # バリデーションチェック、保存、件数カウント
           if alergy_check.valid?(:today_check)
             alergy_check.save
-            @updated += 1
+            updated += 1
           else
-            @unupdated += 1
+            unupdated += 1
           end
         # チェックが抜けている項目があるレコードの場合
         else
-          @unupdated += 1
+          unupdated += 1
         end
       end
       # 報告件数と可否によってフラッシュメッセージの色と内容を変更
-      if @updated >= 1 && @unupdated == 0
-        flash[:success] = "#{@updated}件のチェックを報告しました。"
-      elsif @updated >= 1 && @unupdated >= 1
-        flash[:warning] = "#{@updated}件のチェックを報告しました。報告に失敗したチェックが#{@unupdated}件あります。チェック内容を確認してください。"
+      if updated >= 1 && unupdated == 0
+        flash[:success] = "#{updated}件のチェックを報告しました。"
+        checked_redirect
+      elsif updated >= 1 && unupdated >= 1
+        respond_to do |format|
+          format.js { flash.now[:warning] = "#{updated}件のチェックを報告しました。<br>報告に失敗したチェックも#{unupdated}件あります。チェック内容に不足がないか確認してください。"} 
+          format.js { render 'today_index' }
+        end
       else
-        flash[:danger] = "報告に失敗したチェックが#{@unupdated}件あります。チェック内容を確認してください。"
+        respond_to do |format|
+          format.js { flash.now[:danger] = "報告に失敗したチェックが#{unupdated}件あります。チェック内容に不足がないか確認してください。"} 
+          format.js { render 'today_index' }
+        end
       end
     end
-    # 担任報告か代理報告かでリダイレクト先を分岐
-    checked_redirect
   end
 
   def one_month_index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # ログイン状態でページにアクセスしようとしているかの判定
+  def signed_in_teacher
+    redirect_to alert_path unless current_teacher || current_system_admin
+  end
+
   # 今日の日付からその月の初日と最終日を取得
   def set_first_last_day
     @first_day = params[:date].nil? ? Date.current.beginning_of_month : params[:date].to_date

--- a/app/controllers/charger_alergy_checks_controller.rb
+++ b/app/controllers/charger_alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class ChargerAlergyChecksController < ApplicationController
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :charger_teacher
 

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -1,6 +1,7 @@
 class ClassroomsController < ApplicationController
   include SchoolsHelper
 
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :set_school
   before_action :authenticate_teacher!

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -33,8 +33,11 @@ class CreatorAlergyChecksController < ApplicationController
     redirect_to teachers_creator_alergy_checks_url
 
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
-    flash[:danger] = e.message
-    redirect_to teachers_creator_alergy_checks_url
+    respond_to do |format|
+      # エラーメッセージをうまく取り出せない為、詳しいエラー内容表示ができていない
+      format.js { flash.now[:danger] = "登録に失敗しました。入力内容を確認してください。" }
+      format.js { render 'new' }
+    end
   end
 
   def edit

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -35,7 +35,7 @@ class CreatorAlergyChecksController < ApplicationController
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
     respond_to do |format|
       # エラーメッセージをうまく取り出せない為、詳しいエラー内容表示ができていない
-      format.js { flash.now[:danger] = "登録に失敗しました。入力内容を確認してください。" }
+      format.js { flash.now[:danger] = "登録に失敗しました。入力内容に不備がないか確認してください。" }
       format.js { render 'new' }
     end
   end
@@ -53,14 +53,22 @@ class CreatorAlergyChecksController < ApplicationController
       if @alergy_check.update(edit_creator_params)
         flash[:success] = "#{l(@alergy_check.worked_on, format: :short)}の情報を更新しました。"
       else
-        flash[:danger] = "更新に失敗しました。<br>" + "・" + @alergy_check.errors.full_messages.join("<br>")
+        respond_to do |format|
+          format.js { flash.now[:danger] = "更新に失敗しました。<br>・#{@alergy_check.errors.full_messages.join('<br>・')}"} 
+          format.js { render 'edit' }
+        end
       end
     elsif params[:alergy_check][:student_id].nil?
-      flash[:danger] = "登録に失敗しました。児童の情報が存在しません。入力内容を確認してください。"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "登録に失敗しました。児童の情報が存在しません。入力内容を確認してください。"} 
+        format.js { render 'edit' }
+      end
     else
-      flash[:danger] = "登録に失敗しました。児童名を選択してください。"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "登録に失敗しました。児童名を選択してください。"} 
+        format.js { render 'edit' }
+      end
     end
-    redirect_to teachers_creator_alergy_checks_url
   end
 
   def destroy

--- a/app/controllers/creator_alergy_checks_controller.rb
+++ b/app/controllers/creator_alergy_checks_controller.rb
@@ -1,4 +1,5 @@
 class CreatorAlergyChecksController < ApplicationController
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :creator_teacher
   before_action :set_first_last_day, only: :index

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,6 +1,7 @@
 class MenusController < ApplicationController
   include SchoolsHelper
 
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :set_school
   before_action :set_menu, only: [:show, :edit, :update, :destroy]

--- a/app/controllers/school_students_controller.rb
+++ b/app/controllers/school_students_controller.rb
@@ -1,6 +1,7 @@
 class SchoolStudentsController < ApplicationController
   include SchoolsHelper
 
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
   before_action :set_school
   before_action :set_school_student, only: [:edit, :update, :destroy]

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,10 +1,11 @@
 class StaticPagesController < ApplicationController
-  before_action :teacher_not_show
+  before_action :teacher_not_show, only: [:top]
 
   def top
   end
 
-
+  def alert
+  end
 
   private
     # 職員がシステム管理者TOPページに遷移できないようにする

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,6 @@
 class StaticPagesController < ApplicationController
   before_action :teacher_not_show, only: [:top]
+  before_action :alert_not_show, only: [:alert]
 
   def top
   end
@@ -16,5 +17,10 @@ class StaticPagesController < ApplicationController
       end
     end
 
-
+    # 職員がログインしている間、アラートページは表示されない
+    def alert_not_show
+      if current_teacher
+        redirect_to show_teachers_path
+      end
+    end
 end

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -3,6 +3,7 @@
 
 class Teachers::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :require_no_authentication, only: [:cancel] # ログイン後も新規登録を可能にする為、new、createを外す
+  prepend_before_action :signed_in_teacher, only: [:edit, :update, :destroy]
   prepend_before_action :system_admin_inaccessible
   before_action :creatable?, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -1,7 +1,7 @@
 class TeachersController < ApplicationController
   include SchoolsHelper
+  before_action :signed_in_teacher
   before_action :system_admin_inaccessible
-  before_action :authenticate_teacher!
   before_action :admin_teacher, only: [:new, :create, :edit_info, :update_info, :destroy]
 
   def show

--- a/app/views/admin_alergy_checks/one_month_index.html.erb
+++ b/app/views/admin_alergy_checks/one_month_index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>全学級月間チェック一覧</h1>
 <div class="button__monthly">
   <%= link_to "前月", one_month_index_teachers_admin_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>

--- a/app/views/alergy_checks/_today_index.html.erb
+++ b/app/views/alergy_checks/_today_index.html.erb
@@ -7,7 +7,8 @@
       <h1>【チェック児童一覧】</h1>
 
       <div class="modal-body">
-      <%= form_with(url: teachers_alergy_checks_path, local: true, method: :patch, id: "allergy-check-form") do |f| %>
+      <div id="general-today_index-error"></div>
+      <%= form_with(url: teachers_alergy_checks_path, remote: true, method: :patch, id: "allergy-check-form") do |f| %>
         <table width=100%, class="table table-bordered table-condensed table__alergy-contents--center ">
           <thead>
             <tr>

--- a/app/views/alergy_checks/one_month_index.html.erb
+++ b/app/views/alergy_checks/one_month_index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1><%= current_teacher.classroom.class_name %>月間チェック一覧</h1>
 <div class="button__monthly">
   <%= link_to "前月", one_month_index_teachers_alergy_checks_path(date: @first_day.prev_month), class: "btn btn-info" %>

--- a/app/views/alergy_checks/show.html.erb
+++ b/app/views/alergy_checks/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <div>
   <div class="center contents__font-size">
     <br><%= I18n.l(Date.current, format: :long) %><br><br>

--- a/app/views/alergy_checks/update.js.erb
+++ b/app/views/alergy_checks/update.js.erb
@@ -1,0 +1,4 @@
+//フラッシュメッセージを表示するJSファイル
+<% flash.each do |type, message| %>
+  $("#general-today_index-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %> 

--- a/app/views/charger_alergy_checks/show.html.erb
+++ b/app/views/charger_alergy_checks/show.html.erb
@@ -1,6 +1,6 @@
+<% provide(:title, current_teacher.teacher_name) %>
 
 <h1>代理報告</h1>
-
 <div>
   <div class="center contents__font-size">
     <br><%= I18n.l(Date.current, format: :long) %><br><br>

--- a/app/views/classrooms/edit_using_class.html.erb
+++ b/app/views/classrooms/edit_using_class.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <%= form_with(model: @school, url: update_using_class_classrooms_path(@school), local: true, method: :patch) do |f| %>
   <div>
     <h1>クラス編集画面</h1>

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>職員一覧</h1>
 
 <!--タブ部分-->

--- a/app/views/creator_alergy_checks/_alergy_check_fields.html.erb
+++ b/app/views/creator_alergy_checks/_alergy_check_fields.html.erb
@@ -5,25 +5,22 @@
       <%= f.collection_select :classroom,
         @classrooms, :id, :class_name,
         { include_blank: "クラスを選択" },
-        class: "form-control classroom-select",
-        required: true
+        class: "form-control classroom-select"
       %>
     </td>
     <td class="select--student">
       <%= f.collection_select :student_id,
         [], :id, :student_name,
         { include_blank: "児童名を選択" },
-        class: "form-control student-select",
-        required: true
+        class: "form-control student-select"
       %>
     </td>
-    <td><%= f.text_field :menu, required: true, class: "form-control" %></td>
+    <td><%= f.text_field :menu, class: "form-control" %></td>
     <td>
       <%= f.select :support,
         ['対応食', '代替食', '除去食', 'その他'],
         { include_blank: "対応を選択" },
-        class: "form-control",
-        required: true
+        class: "form-control"
       %>
     </td>
     <td><%= f.text_field :note, class: "form-control" %></td>

--- a/app/views/creator_alergy_checks/_alergy_check_fields.html.erb
+++ b/app/views/creator_alergy_checks/_alergy_check_fields.html.erb
@@ -5,22 +5,25 @@
       <%= f.collection_select :classroom,
         @classrooms, :id, :class_name,
         { include_blank: "クラスを選択" },
-        class: "form-control classroom-select"
+        class: "form-control classroom-select",
+        required: true
       %>
     </td>
     <td class="select--student">
       <%= f.collection_select :student_id,
         [], :id, :student_name,
         { include_blank: "児童名を選択" },
-        class: "form-control student-select"
+        class: "form-control student-select",
+        required: true
       %>
     </td>
-    <td><%= f.text_field :menu, class: "form-control" %></td>
+    <td><%= f.text_field :menu, required: true, class: "form-control" %></td>
     <td>
       <%= f.select :support,
         ['対応食', '代替食', '除去食', 'その他'],
         { include_blank: "対応を選択" },
-        class: "form-control"
+        class: "form-control",
+        required: true
       %>
     </td>
     <td><%= f.text_field :note, class: "form-control" %></td>

--- a/app/views/creator_alergy_checks/_edit.html.erb
+++ b/app/views/creator_alergy_checks/_edit.html.erb
@@ -7,9 +7,10 @@
     </div>
 
     <div class="modal-body">
-      <h1>対応法登録</h1>
+      <h1>対応法編集</h1>
+      <div id="creator-edit-error"></div>
       <div>
-        <%= form_with model: @alergy_check, url: teachers_creator_alergy_check_path(@alergy_check.id) do |f| %>
+        <%= form_with model: @alergy_check, url: teachers_creator_alergy_check_path(@alergy_check.id), remote: true do |f| %>
           <table class="table table-bordered table-condensed table-hover table__alergy-contents--center">
             <thead>
               <tr>

--- a/app/views/creator_alergy_checks/_new.html.erb
+++ b/app/views/creator_alergy_checks/_new.html.erb
@@ -9,7 +9,7 @@
 
       <div class="modal-body">
         <h1>対応法登録</h1>
-        <div id="creator-error"></div>
+        <div id="creator-new-error"></div>
         <div>
           <%= form_with(model: @student, url: teachers_creator_alergy_checks_path, remote: true) do |f| %>
             <table class="table table-bordered table-condensed table-hover table__alergy-contents--center">

--- a/app/views/creator_alergy_checks/_new.html.erb
+++ b/app/views/creator_alergy_checks/_new.html.erb
@@ -9,8 +9,9 @@
 
       <div class="modal-body">
         <h1>対応法登録</h1>
+        <div id="creator-error"></div>
         <div>
-          <%= form_with(model: @student, url: teachers_creator_alergy_checks_path) do |f| %>
+          <%= form_with(model: @student, url: teachers_creator_alergy_checks_path, remote: true) do |f| %>
             <table class="table table-bordered table-condensed table-hover table__alergy-contents--center">
               <thead>
                 <tr>

--- a/app/views/creator_alergy_checks/create.js.erb
+++ b/app/views/creator_alergy_checks/create.js.erb
@@ -1,4 +1,4 @@
 //フラッシュメッセージを表示するJSファイル
 <% flash.each do |type, message| %>
-  $("#creator-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+  $("#creator-new-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
 <% end %> 

--- a/app/views/creator_alergy_checks/create.js.erb
+++ b/app/views/creator_alergy_checks/create.js.erb
@@ -1,0 +1,4 @@
+//フラッシュメッセージを表示するJSファイル
+<% flash.each do |type, message| %>
+  $("#creator-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %> 

--- a/app/views/creator_alergy_checks/index.html.erb
+++ b/app/views/creator_alergy_checks/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1><%= l(@first_day, format: :middle) %> 対応法詳細</h1>
 
 <div class="button__creator">

--- a/app/views/creator_alergy_checks/update.js.erb
+++ b/app/views/creator_alergy_checks/update.js.erb
@@ -1,0 +1,4 @@
+//フラッシュメッセージを表示するJSファイル
+<% flash.each do |type, message| %>
+  $("#creator-edit-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %> 

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>献立表一覧</h1>
 
 <!--献立追加ボタン-->

--- a/app/views/school_students/index.html.erb
+++ b/app/views/school_students/index.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>児童一覧ページ</h1>
 
 <!--児童追加ボタン-->

--- a/app/views/static_pages/alert.html.erb
+++ b/app/views/static_pages/alert.html.erb
@@ -1,0 +1,5 @@
+<% provide(:title, "Alert") %>
+<div class="center jumbotron">
+  <p>指定されたURLからログインをお願いいたします。</p>
+  <%= link_to "前のページに戻る", :back, class: "btn btn-default" %>
+</div>

--- a/app/views/teachers/registrations/edit.html.erb
+++ b/app/views/teachers/registrations/edit.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>アカウント編集</h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/teachers/show.html.erb
+++ b/app/views/teachers/show.html.erb
@@ -1,3 +1,5 @@
+<% provide(:title, current_teacher.teacher_name) %>
+
 <h1>本日の作業選択</h1>
 <div class="center contents__font-size">
   <%= I18n.l(Date.current, format: :long) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 
   root 'static_pages#top'
+
+  # 職員未ログイン時リダイレクト画面
   get '/alert', to: 'static_pages#alert'
 
   # システム管理者用画面

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
 
-
-
   root 'static_pages#top'
+  get '/alert', to: 'static_pages#alert'
 
   # システム管理者用画面
   devise_for :system_admins, controllers: {


### PR DESCRIPTION
【作業内容】
①未ログイン時リダイレクト用のメッセージページを作成、各学校ページのコントローラにbefore_actionを追加
②チェック児童一覧モーダル(自クラス報告、代理報告共通)のビューとアクションを修正 
③対応法入力モーダルのビューとアクションを修正
④対応法編集モーダルのビューとアクションを修正
⑤各学校ページのビューにタグの表示設定を追加
⑥チェック児童一覧更新件数カウント用変数を、インスタンス変数からローカル変数に変更

【期待される動作】
①未ログイン状態で、各学校の職員向けページにURL直打ちで遷移した場合、「指定されたURLからログインをお願いいたします。」というメッセージが表記されたページへリダイレクトする。ログイン後、/alertにアクセスすると、本日の作業選択ページへリダイレクトする。

https://user-images.githubusercontent.com/63346413/147443026-eae9d6ed-4306-43a8-a44e-19b34c0497a5.mov

②、③、④バリデーションエラー出た場合、ページ遷移せずモーダル内にエラーメッセージが表示される。
②チェック児童一覧

https://user-images.githubusercontent.com/63346413/147443298-75b1ac3d-a75f-49cc-8627-21dea374d09c.mov

③対応法入力

https://user-images.githubusercontent.com/63346413/147443165-36621fef-795e-479a-b490-b0329c96aa81.mov

④対応法編集

https://user-images.githubusercontent.com/63346413/147443229-7b68cf7a-86d6-4b4c-8114-0f2966ee4111.mov

⑤ページタグに現在ログインしている職員の名前が表示される。
<img width="242" alt="スクリーンショット 2021-12-27 15 05 57" src="https://user-images.githubusercontent.com/63346413/147440692-dcf01a22-b29e-4ea1-a94d-39601c1dcaec.png">
⑥特になし

【共有事項】
②、③、④ビュー側のバリデーションを外した状態で動作確認し、再度ビュー側のバリデーションを追加し直しています。
③エラー箇所が複数あっても、1つ目のエラーメッセージしか取り出せなかったので(トランザクションを用いているため？)、更新できなかった旨と、入力内容の確認を促すメッセージを表示させるようにしています。
⑤・管理職以外のユーザーが現在ログインしているユーザーを把握するための情報がないと思った
　・一部既に⑤の実装がされているページがあった
　以上の2点を以て、他のページタグにも同じように表示を追加しました。