### PR TITLE
Fix admin

### DIFF
--- a/app/controllers/school_students_controller.rb
+++ b/app/controllers/school_students_controller.rb
@@ -22,7 +22,6 @@ class SchoolStudentsController < ApplicationController
     @school_student = @school.students.new(student_params)
     if @school_student.save
       flash[:success] = '児童を追加しました。'
-      redirect_to teachers_school_students_path and return
     else
       flash[:danger] = "追加に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"
     end
@@ -41,11 +40,10 @@ class SchoolStudentsController < ApplicationController
   def update
     if @school_student.update_attributes(student_params)
       flash[:success] = "児童情報を更新しました。"
-      redirect_to teachers_school_students_path and return
     else
       flash[:danger] = "更新に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"
-  end
-  redirect_to teachers_school_students_path and return
+    end
+    redirect_to teachers_school_students_path and return
   end
   
   # 児童削除

--- a/app/controllers/school_students_controller.rb
+++ b/app/controllers/school_students_controller.rb
@@ -23,10 +23,13 @@ class SchoolStudentsController < ApplicationController
     @school_student = @school.students.new(student_params)
     if @school_student.save
       flash[:success] = '児童を追加しました。'
+      redirect_to teachers_school_students_path and return
     else
-      flash[:danger] = "追加に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "作成に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'new' }
+      end
     end
-    redirect_to teachers_school_students_path and return
   end
 
   def show
@@ -41,10 +44,13 @@ class SchoolStudentsController < ApplicationController
   def update
     if @school_student.update_attributes(student_params)
       flash[:success] = "児童情報を更新しました。"
+      redirect_to teachers_school_students_path and return
     else
-      flash[:danger] = "更新に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "更新に失敗しました。<br>・#{@school_student.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'edit' }
+      end
     end
-    redirect_to teachers_school_students_path and return
   end
   
   # 児童削除

--- a/app/controllers/system_admins/schools_controller.rb
+++ b/app/controllers/system_admins/schools_controller.rb
@@ -18,10 +18,13 @@ class SystemAdmins::SchoolsController < ApplicationController
     set_class
     if @school.save
       flash[:info] = "学校を新規作成しました"
+      redirect_to system_admins_schools_url
     else
-      flash[:danger] = "作成に失敗しました。<br>・#{@school.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "作成に失敗しました。<br>・#{@school.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'new' }
+      end
     end
-    redirect_to system_admins_schools_url
   end
 
   def edit
@@ -30,10 +33,13 @@ class SystemAdmins::SchoolsController < ApplicationController
   def update
     if @school.update_attributes(school_params)
       flash[:success] = "学校情報を更新しました。"
+      redirect_to system_admins_schools_url
     else
-      flash[:danger] = "更新に失敗しました。<br>・#{@school.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "更新に失敗しました。<br>・#{@school.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'edit' }
+      end
     end
-    redirect_to system_admins_schools_url
   end
 
   def destroy

--- a/app/controllers/system_admins/teachers_controller.rb
+++ b/app/controllers/system_admins/teachers_controller.rb
@@ -15,17 +15,20 @@ class SystemAdmins::TeachersController < ApplicationController
     @admin_teacher.admin = true
     if @admin_teacher.save
       flash[:info] = "学校管理者を作成しました"
+      redirect_to system_admins_schools_path
     else
-      flash[:danger] = "作成に失敗しました。<br>・#{@admin_teacher.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "作成に失敗しました。<br>・#{@admin_teacher.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'new' }
+      end
     end
-    redirect_to system_admins_schools_path
   end
 
-  # 必要かどうか確認↓
+  # 一旦不要↓
   def edit
   end
 
-  # 必要かどうか確認↓
+  # 一旦不要↓
   def update
     if @admin_teacher.update_attributes(admin_teacher_params)
       flash[:success] = "学校管理者情報を更新しました。"

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -5,6 +5,7 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :require_no_authentication, only: [:cancel] # ログイン後も新規登録を可能にする為、new、createを外す
   prepend_before_action :system_admin_inaccessible
   before_action :creatable?, only: [:new, :create]
+  before_action :set_classrooms, only: [:edit, :update]
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
   before_action :admin_teacher, only: [:new, :create, :edit, :update, :destroy]
@@ -27,13 +28,12 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
 
   # GET /resource/edit
   def edit
-    @classrooms = current_teacher.school.classrooms.where(using_class: true).order(:id)
   end
 
   # PUT /resource
-  def update
-    @classrooms = current_teacher.school.classrooms.where(using_class: true).order(:id)
-  end
+  # def update
+  #   super
+  # end
 
   # DELETE /resource
   # def destroy
@@ -65,11 +65,11 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [:teacher_name, :tcode, :email, :password, :password_confirmation, :admin, :creator, :charger, :school_id, :classroom_id])
   end
 
-  # 一般職員新規登録時のストロングパラメーター
-  def ippan_sign_up_params
-    params.require(:teacher).permit(:teacher_name, :tcode, :password, :password_confirmation, :school_id, :classroom_id, :admin, :creator, :charger)
-    # devise_parameter_sanitizer.permit(:sign_up, keys: %i(teacher_name tcode password school_id classroom_id))
+  # 編集時のクラスルームの表示
+  def set_classrooms
+    @classrooms = current_teacher.school.classrooms.where(using_class: true).order(:id)
   end
+
 
   # 学校管理者かどうかの判定
   def current_teacher_is_admin?

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -17,9 +17,11 @@ class TeachersController < ApplicationController
       flash[:success] = "担任を作成しました。"
       redirect_to classrooms_path and return
     else
-      flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "更新に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'new' }
+      end
     end
-    redirect_to classrooms_path and return
   end
 
   def edit_info
@@ -31,10 +33,13 @@ class TeachersController < ApplicationController
     @teacher = current_school.teachers.find(params[:teacher][:id])
     if @teacher.update_attributes(teachers_params)
       flash[:success] = "#{@teacher.teacher_name}の情報を更新しました。"
+      redirect_to classrooms_path
     else
-      flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"
+      respond_to do |format|
+        format.js { flash.now[:danger] = "更新に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"} 
+        format.js { render 'edit_info' }
+      end
     end
-    redirect_to classrooms_path
   end
 
   def destroy

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -5,6 +5,6 @@ class Classroom < ApplicationRecord
   accepts_nested_attributes_for :students, allow_destroy: true
   has_many :alergy_checks, through: :students
 
-  validates :class_name, length: { maximum: 20 }, uniqueness: { scope: :school_id }
+  validates :class_name, presence: true, length: { maximum: 20 }, uniqueness: { scope: :school_id }
 
 end

--- a/app/views/school_students/_edit.html.erb
+++ b/app/views/school_students/_edit.html.erb
@@ -7,7 +7,8 @@
       <h1>児童編集</h1>
     </div>
     <div class="modal-body">
-      <%= form_with model: @school_student, url: teachers_school_student_path(@school_student), local: true, method: :patch do |f| %>
+      <div id="students-error"></div>
+      <%= form_with model: @school_student, url: teachers_school_student_path(@school_student), remote: true, method: :patch do |f| %>
         <table class="table table-bordered table-condensed table-hover">
           <thead>
             <tr>

--- a/app/views/school_students/_new.html.erb
+++ b/app/views/school_students/_new.html.erb
@@ -7,7 +7,8 @@
       <h1>児童追加</h1>
     </div>
     <div class="modal-body">
-      <%= form_with model: @school_student, url: teachers_school_students_path, local: true do |f| %>
+      <div id="students-error"></div>
+      <%= form_with model: @school_student, url: teachers_school_students_path, remote: true do |f| %>
         <table class="table table-bordered table-condensed table-hover">
           <thead>
             <tr>

--- a/app/views/school_students/create.js.erb
+++ b/app/views/school_students/create.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#students-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/school_students/update.js.erb
+++ b/app/views/school_students/update.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#students-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/system_admins/schools/_edit.html.erb
+++ b/app/views/system_admins/schools/_edit.html.erb
@@ -7,10 +7,8 @@
       <h1>学校情報編集</h1>
     </div>
     <div class="modal-body">
-      <%= form_with(model: @school, url: system_admins_school_path, local: true, method: :patch) do |f| %>
-        <%= render 'layouts/flash_messages' %>
-        <%= render 'layouts/model_error_messages', model: @school %>
-
+      <div id="schools-error"></div>
+      <%= form_with(model: @school, url: system_admins_school_path, remote: true, method: :patch) do |f| %>
         <div class="form-group">
           <%= f.label :school_name %>
           <%= f.text_field :school_name, placeholder: "学校名を入力してください（必須）", class: "form-control", required: true %>

--- a/app/views/system_admins/schools/_new.html.erb
+++ b/app/views/system_admins/schools/_new.html.erb
@@ -7,10 +7,8 @@
       <h1>学校新規作成</h1>
     </div>
     <div class="modal-body">
-      <%= form_with(model: @school, url: system_admins_schools_path, local: true) do |f| %>
-        <%= render 'layouts/flash_messages' %>
-        <%= render 'layouts/model_error_messages', model: @school %>
-
+      <div id="schools-error"></div>
+      <%= form_with(model: @school, url: system_admins_schools_path, remote: true) do |f| %>
         <div class="form-group">
           <%= f.label :school_name %>
           <%= f.text_field :school_name, placeholder: "学校名を入力してください（必須）", class: "form-control", required: true %>

--- a/app/views/system_admins/schools/create.js.erb
+++ b/app/views/system_admins/schools/create.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#schools-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/system_admins/schools/update.js.erb
+++ b/app/views/system_admins/schools/update.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#schools-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/system_admins/teachers/_new.html.erb
+++ b/app/views/system_admins/teachers/_new.html.erb
@@ -7,9 +7,8 @@
       <h1>学校管理者作成</h1>
     </div>
     <div class="modal-body">
-      <%= form_with(model: @admin_teacher, url: system_admins_school_teachers_path(@school), local: true) do |f| %>
-        <%= render 'layouts/flash_messages' %>
-
+      <div id="adminteacher-error"></div>
+      <%= form_with(model: @admin_teacher, url: system_admins_school_teachers_path(@school), remote: true) do |f| %>
         <div class="field">
           <%= f.label :teacher_name %>
           <%= f.text_field :teacher_name, placeholder: "名前を入力してください（必須）", class: "form-control", required: true %>

--- a/app/views/system_admins/teachers/create.js.erb
+++ b/app/views/system_admins/teachers/create.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#adminteacher-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/teachers/_edit_info.html.erb
+++ b/app/views/teachers/_edit_info.html.erb
@@ -7,9 +7,8 @@
     </div>
     <div class="modal-body">
       <h1><%= @teacher.classroom_id == nil ? "#{@teacher.teacher_name}の編集" : "#{params[:class_name]}の担任編集" %></h1>
-      <%= form_with(model: @teacher, url: update_info_teachers_path, local: true) do |f| %>
-        <%= render 'shared/error_messages', object: @teacher %>
-      
+      <div id="teachers-error"></div>
+      <%= form_with(model: @teacher, url: update_info_teachers_path, remote: true) do |f| %>      
         <!-- %= f.hidden_field(:school_id, value: @school.id) % -->
         <%= f.hidden_field(:classroom_id, value: @teacher.classroom_id) %>
         <%= f.hidden_field(:id, value: @teacher.id) %>

--- a/app/views/teachers/_new.html.erb
+++ b/app/views/teachers/_new.html.erb
@@ -11,8 +11,8 @@
       <% else %>
         <h1>職員登録</h1>
       <% end %>
-      <%= form_with(model: @teacher, local: true) do |f| %>
-        <!--%= f.hidden_field(:school_id, value: @school.id) % -->
+      <div id="teachers-error"></div>
+      <%= form_with(model: @teacher, remote: true) do |f| %>
         <%= f.hidden_field(:classroom_id, value: params[:classroom_id]) %>
 
         <div class="form-group">

--- a/app/views/teachers/create.js.erb
+++ b/app/views/teachers/create.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#teachers-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/app/views/teachers/update_info.js.erb
+++ b/app/views/teachers/update_info.js.erb
@@ -1,0 +1,5 @@
+//フラッシュメッセージを表示するJSファイル
+
+<% flash.each do |type, message| %>
+  $("#teachers-error").html('<p class="alert alert-danger"><%= message.html_safe %></p>')
+<% end %>

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -32,9 +32,9 @@ ja:
           created_at: 作成日
           updated_at: 更新日
         classroom:
-          class_name: 学級名
-          class_grade:
-          using_class:
+          class_name: クラス名
+          class_grade: 学年
+          using_class: 使用クラス
           created_at: 作成日
           updated_at: 更新日
         teacher:


### PR DESCRIPTION
### 実装した事
１、【クラス編集ページ】編集時にデータが更新されない不具合の修正
　→以前のコードに戻し、少し修正を加えました。

２、【学校管理者アカウント編集ページ】にて、パスワード無しで更新時にエラーが出る不具合修正

３、各ページのモーダルに動的なバリデーションエラーを追加
　→各ページ名：https://trello.com/c/yI0LIq8g

### 期待される動作
１、クラス編集にて更新処理が出来、職員一覧ページにも反映される事、及び、クラス名が学校内で被った場合更新出来ない事

https://user-images.githubusercontent.com/63439936/147491561-bf7d069f-9009-4da6-a482-d895699e5459.mov



２、更新の際、現在のパスワードを入力しないと更新出来ない事

https://user-images.githubusercontent.com/63439936/147491594-d8ef7683-6acc-43e8-b013-5c2661bbbc12.mov


３、モーダル更新時、各モデルのバリデーションエラーがモーダル内にそのまま表示される事

https://user-images.githubusercontent.com/63439936/147491629-196fe884-6eb6-4fb6-aaef-a7c56eeaaf0c.mov


