### PR TITLE
システム管理者ページビュー、一部機能の変更

### DIFF
--- a/app/views/system_admins/registrations/edit.html.erb
+++ b/app/views/system_admins/registrations/edit.html.erb
@@ -35,4 +35,4 @@
   </div>
 <% end %>
 
-<%= link_to t('devise.shared.links.back'), :back, class: 'btn btn-default btn-block' %>
+<%= link_to "学校一覧へ戻る", system_admins_schools_path, class: 'btn btn-default btn-block' %>

--- a/app/views/system_admins/registrations/edit.html.erb
+++ b/app/views/system_admins/registrations/edit.html.erb
@@ -13,20 +13,20 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
+    <%= f.label :new_password %>
     <% if @minimum_password_length %>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+      <b><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></b>
     <% end %>
+    <%= f.password_field :password, autocomplete: "new-password", placeholder: "変更する場合は入力してください", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
+    <%= f.label :new_password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "変更する場合は入力してください", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
+    <%= f.label :current_password %> <b>（入力必須）</b><br />
     <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -17,6 +17,8 @@ ja:
         locked_at: ロック時刻
         password: パスワード
         password_confirmation: パスワード（確認用）
+        new_password: 新しいパスワード
+        new_password_confirmation: 新しいパスワード（確認用）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻


### PR DESCRIPTION
【作業内容】
①戻るボタンの遷移先を変更。
②以下3箇所のラベルを変更、プレースホルダを追加。
・パスワード (空欄のままなら変更しません)（6字以上）→新しいパスワード(6文字以上)[変更する場合は入力してください]
・パスワード(確認用)→新しいパスワード(確認用)[変更する場合は入力してください]
・現在のパスワード (変更を反映するには現在のパスワードを入力してください)→現在のパスワード(入力必須)
<img width="1165" alt="スクリーンショット 2021-12-29 12 42 45" src="https://user-images.githubusercontent.com/63346413/147625717-319ee367-8833-49ec-ac9d-2f2a02b26d03.png">


【期待される動作】
①クリックで学校一覧ページへ遷移する。

https://user-images.githubusercontent.com/63346413/147625730-387e7197-1fbc-441a-8a38-59bafb260b3b.mov


②特になし

【共有事項】
①に関して、戻る先が1つ前のページでは無くなったので「戻る」より「学校一覧へ戻る」の方が適切かと思い、そのように変更しました。