### PR TITLE
学校管理者ページビューの修正

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -14,7 +14,7 @@ class TeachersController < ApplicationController
   def create
     @teacher = current_school.teachers.new(teachers_params)
     if @teacher.save
-      flash[:success] = "担任を作成しました。"
+      flash[:success] = teachers_params[:classroom_id].blank? ? "職員を作成しました。" : "担任を作成しました。"
       redirect_to classrooms_path and return
     else
       flash[:danger] = "作成に失敗しました。<br>・#{@teacher.errors.full_messages.join('<br>・')}"

--- a/app/views/system_admins/registrations/edit.html.erb
+++ b/app/views/system_admins/registrations/edit.html.erb
@@ -17,17 +17,17 @@
     <% if @minimum_password_length %>
       <b><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></b>
     <% end %>
-    <%= f.password_field :password, autocomplete: "new-password", placeholder: "変更する場合は入力してください", class: 'form-control' %>
+    <%= f.password_field :password, placeholder: "変更する場合は入力してください", autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :new_password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "変更する場合は入力してください", class: 'form-control' %>
+    <%= f.label :new_password_confirmation %>
+    <%= f.password_field :password_confirmation, placeholder: "変更する場合は入力してください", autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :current_password %> <b>（入力必須）</b><br />
-    <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
+    <%= f.label :current_password %>
+    <%= f.password_field :current_password, placeholder: "現在のパスワードを入力してください（必須）", autocomplete: "current-password", class: 'form-control' %>
   </div>
 
   <div class="actions">

--- a/app/views/teachers/registrations/edit.html.erb
+++ b/app/views/teachers/registrations/edit.html.erb
@@ -43,20 +43,20 @@
   </div><br>
 
   <div class="form-group">
-    <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i>
-    <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
+    <%= f.label :new_password %>
     <% if @minimum_password_length %>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+      <b><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></b>
     <% end %>
+    <%= f.password_field :password, placeholder: "変更する場合は入力してください", autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
+    <%= f.label :new_password_confirmation %>
+    <%= f.password_field :password_confirmation, placeholder: "変更する場合は入力してください", autocomplete: "new-password", class: 'form-control' %>
   </div>
 
   <div class="form-group">
-    <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i>
+    <%= f.label :current_password %>
     <%= f.password_field :current_password, placeholder: "現在のパスワードを入力してください（必須）", autocomplete: "current-password", class: 'form-control' %><br>
   </div>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -43,6 +43,8 @@ ja:
         locked_at: ロック時刻
         password: パスワード
         password_confirmation: パスワード（確認用）
+        new_password: 新しいパスワード
+        new_password_confirmation: 新しいパスワード（確認用）
         remember_created_at: ログイン記憶時刻
         remember_me: ログインを記憶する
         reset_password_sent_at: パスワードリセット送信時刻


### PR DESCRIPTION
【作業内容】
①クラスを持たない職員登録後のフラッシュメッセージを変更。
②アカウント編集画面のビューを修正。
<img width="1165" alt="スクリーンショット 2021-12-29 14 22 02" src="https://user-images.githubusercontent.com/63346413/147631531-89e1f62d-350d-4bc8-b248-10964e7e382e.png">

③システム管理者アカウント編集画面のビューを再修正。
<img width="1164" alt="スクリーンショット 2021-12-29 14 20 57" src="https://user-images.githubusercontent.com/63346413/147631552-53c773cc-501d-4bca-9b3d-1b48441fbe68.png">

【期待される動作】
①担任登録後は「担任を登録しました。」クラスを持たない職員の登録後は、「職員を登録しました。」というフラッシュメッセージが表示される。※牧野さんPRマージ分反映前に収録した動画なので、その他の職員作成後も1学年のページに遷移しています。

https://user-images.githubusercontent.com/63346413/147631731-ba275a80-2d37-4951-8bee-f3563b95cfdd.mov


②、③特になし

【共有事項】
・②の現在のパスワード欄は、私が着手した時点で既にプレースホルダが追加されている状態だったので、ラベルの表示のみ変更しました。
・③は、現在のパスワード欄が②と同じ見た目になるよう再度修正しました。
・②のページに「戻る」ボタンがあるのですが、システム管理者アカウント編集ページの「戻る」ようなおかしな挙動にはならずきちんと1つ前のページに遷移するので、特に手は加えていません。